### PR TITLE
Allow documenting responses

### DIFF
--- a/cornice_swagger/__init__.py
+++ b/cornice_swagger/__init__.py
@@ -10,9 +10,6 @@ class ResponseSchemaPredicate(object):
     def phash(self):
         return str(self.schema)
 
-    def __call__(self, context, request):
-        return self.schema
-
 
 def includeme(config):
     config.add_view_predicate('response_schemas', ResponseSchemaPredicate)

--- a/cornice_swagger/__init__.py
+++ b/cornice_swagger/__init__.py
@@ -1,5 +1,18 @@
-# -*- coding: utf-8 -*-
-
 __author__ = """Josip Delic"""
 __email__ = 'delicj@delijati.net'
-__version__ = '0.1.0'
+__version__ = '0.3.0'
+
+
+class ResponseSchemaPredicate(object):
+    def __init__(self, schema, config):
+        self.schema = schema
+
+    def phash(self):
+        return str(self.schema)
+
+    def __call__(self, context, request):
+        return self.schema
+
+
+def includeme(config):
+    config.add_view_predicate('response_schemas', ResponseSchemaPredicate)

--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -217,7 +217,7 @@ class CorniceSwagger(object):
 
         # Get response definitions
         if 'response_schemas' in args:
-            op['responses'] = self.responses.from_schema(args['response_schemas'])
+            op['responses'] = self.responses.from_schema_mapping(args['response_schemas'])
 
         return op
 
@@ -411,22 +411,19 @@ class ResponseHandler(object):
         self.definitions = definition_handler
         self.ref = ref
 
-    def from_schema(self, schema_node, content_type='application/json'):
+    def from_schema_mapping(self, schema_mapping):
         """
-        Creates a Swagger response object from a colander response schema.
+        Creates a Swagger response object from a dict of response schemas.
 
-        :param schema_node:
-            Response schema to be transformed into Swagger.
-        :rtype: list
+        :param schema_mapping:
+            Dict with entries matching ``{status_code: response_schema}``.
+        :rtype: dict
             Response schema.
         """
 
         responses = {}
 
-        if not isinstance(schema_node, colander.Schema):
-            schema_node = schema_node()
-
-        for response_schema in schema_node.children:
+        for status, response_schema in schema_mapping.items():
 
             response = {}
             if response_schema.description:
@@ -446,7 +443,7 @@ class ResponseHandler(object):
 
             pointer = response_schema.__class__.__name__
             response = self._ref(response, self.ref, pointer)
-            responses[response_schema.name] = response
+            responses[status] = response
 
         return responses
 

--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -216,8 +216,8 @@ class CorniceSwagger(object):
             op['summary'] = docstring
 
         # Get response definitions
-        if 'response_schema' in args:
-            op['responses'] = self.responses.from_schema(args['response_schema'])
+        if 'response_schemas' in args:
+            op['responses'] = self.responses.from_schema(args['response_schemas'])
 
         return op
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,9 +2,11 @@ coverage
 coveralls
 flake8
 flex
+pyramid
 pytest
 pytest-cache
 pytest-capturelog
 pytest-cover
 pytest-sugar
 tox
+webtest

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -30,13 +30,18 @@ those if you want to change the converters behaviour.
 .. autoclass:: cornice_swagger.swagger.DefinitionHandler
 .. automethod:: cornice_swagger.swagger.DefinitionHandler.__init__
 .. automethod:: cornice_swagger.swagger.DefinitionHandler.from_schema
-.. automethod:: cornice_swagger.swagger.DefinitionHandler._ref
+.. automethod:: cornice_swagger.swagger.DefinitionHandler._ref_recursive
 
 .. autoclass:: cornice_swagger.swagger.ParameterHandler
 .. automethod:: cornice_swagger.swagger.ParameterHandler.__init__
 .. automethod:: cornice_swagger.swagger.ParameterHandler.from_schema
 .. automethod:: cornice_swagger.swagger.ParameterHandler.from_path
 .. automethod:: cornice_swagger.swagger.ParameterHandler._ref
+
+.. autoclass:: cornice_swagger.swagger.ResponseHandler
+.. automethod:: cornice_swagger.swagger.ResponseHandler.__init__
+.. automethod:: cornice_swagger.swagger.ResponseHandler.from_schema_mapping
+.. automethod:: cornice_swagger.swagger.ResponseHandler._ref
 
 Colander converters
 ===================

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -11,7 +11,20 @@ You may install us with pip::
     $ pip install cornice_swagger
 
 
-From an existing Cornice application, you may create you OpenAPI/Swagger JSON using:
+From an existing Cornice application, you may add this extension to your
+Pyramid configurator after including cornice:
+
+.. code-block:: python
+
+    from pyramid.config import Configurator
+
+    def setup():
+        config = Configurator()
+        config.include('cornice')
+        config.include('cornice_swagger')
+
+
+ and create your OpenAPI/Swagger JSON using:
 
 .. code-block:: python
 
@@ -25,79 +38,8 @@ From an existing Cornice application, you may create you OpenAPI/Swagger JSON us
 Show me a minimalist useful example
 ===================================
 
-.. code-block:: python
-
-    import colander
-    from cornice import Service
-    from cornice.service import get_services
-    from cornice.validators import colander_body_validator
-    from wsgiref.simple_server import make_server
-    from pyramid.config import Configurator
-    from cornice_swagger.swagger import CorniceSwagger
-
-    _VALUES = {}
-
-    # Create a simple service that will store and retrieve values
-    values = Service(name='foo',
-                     path='/values/{value}',
-                     description="Cornice Demo")
-
-
-    # Create a request schema for storing values
-    class PutBodySchema(colander.MappingSchema):
-        value = colander.SchemaNode(colander.String(),
-                                    description='My precious value')
-
-
-    # Create our cornice service views
-    class MyValueApi(object):
-        """My precious API."""
-
-        @values.get()
-        def get_value(request):
-            """Returns the value."""
-            key = request.matchdict['value']
-            return _VALUES.get(key)
-
-        @values.put(validators=(colander_body_validator, ),
-                    schema=PutBodySchema())
-        def set_value(request):
-            """Set the value and returns *True* or *False*."""
-
-            key = request.matchdict['value']
-            try:
-                _VALUES[key] = request.json_body
-            except ValueError:
-                return False
-            return True
-
-
-    # Create a service to serve our OpenAPI spec
-    swagger = Service(name='OpenAPI',
-                      path='/__api__',
-                      description="OpenAPI documentation")
-
-
-    @swagger.get()
-    def openAPI_spec(request):
-        my_generator = CorniceSwagger(get_services())
-        my_spec = my_generator('MyAPI', '1.0.0')
-        return my_spec
-
-
-    # Setup and run our app
-    def setup():
-        config = Configurator()
-        config.include("cornice")
-        config.scan()
-        app = config.make_wsgi_app()
-        return app
-
-
-    if __name__ == '__main__':
-        app = setup()
-        server = make_server('127.0.0.1', 8000, app)
-        server.serve_forever()
+.. literalinclude:: ../../examples/minimalist.py
+    :language: python
 
 
 The resulting `swagger.json` at `http://localhost:8000/__api__` is:
@@ -131,28 +73,38 @@ The resulting `swagger.json` at `http://localhost:8000/__api__` is:
                 ],
                 "get": {
                     "summary": "Returns the value.",
-                    "responses": {
-                        "default": {
-                            "description": "UNDOCUMENTED RESPONSE"
-                        }
-                    },
                     "tags": [
                         "values"
                     ],
+                    "responses": {
+                        "200": {
+                            "description": "Return value",
+                            "schema": {
+                                "required": [
+                                    "value"
+                                ],
+                                "type": "object",
+                                "properties": {
+                                    "value": {
+                                        "type": "string",
+                                        "description": "My precious value",
+                                        "title": "Value"
+                                    }
+                                },
+                                "title": "BodySchema"
+                            }
+                        }
+
+                    },
                     "produces": [
                         "application/json"
                     ]
                 },
                 "put": {
+                    "summary": "Set the value and returns *True* or *False*.",
                     "tags": [
                         "values"
                     ],
-                    "summary": "Set the value and returns *True* or *False*.",
-                    "responses": {
-                        "default": {
-                            "description": "UNDOCUMENTED RESPONSE"
-                        }
-                    },
                     "parameters": [
                         {
                             "name": "PutBodySchema",
@@ -176,7 +128,26 @@ The resulting `swagger.json` at `http://localhost:8000/__api__` is:
                     ],
                     "produces": [
                         "application/json"
-                    ]
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Return value",
+                            "schema": {
+                                "required": [
+                                    "value"
+                                ],
+                                "type": "object",
+                                "properties": {
+                                    "value": {
+                                        "type": "string",
+                                        "description": "My precious value",
+                                        "title": "Value"
+                                    }
+                                },
+                                "title": "BodySchema"
+                            }
+                        }
+                    }
                 }
             },
             "/__api__": {

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -197,20 +197,22 @@ For that you must provide a Response Colander Schema that follows the pattern:
         body = BodySchema()
         headers = HeaderSchema()
 
-    class GetResponseSchemas(colander.MappingSchema):
-        ok = ResponseSchema(name='200', description='Returns my OK response')
-        not_found = ResponseSchema(name='404',
-                                   description='Return my not found response')
+
+    get_response_schemas = {
+        '200': ResponseSchema(description='Returns my OK response'),
+        '404': ResponseSchema(description='Return my not found response')
+    }
 
 
 Notice that the ``ResponseSchema`` class follows the same pattern as the
 Cornice requests using ``cornice.validators.colander_validator``
 (except for querystrings, since obviously we don't have querystrings on responses).
 
-The ``GetResponseSchemas`` class should aggregate response schemas as the one
-defined as ``ResponseSchema`` with names following the response status code of the
-expected responses and non-empty descriptions. You may also provide a ``default``
-response schema to be used if the response doesn't match any of the status provided.
+A response schema mapping, as the ``get_response_schemas`` dict should aggregate
+response schemas as the one defined as ``ResponseSchema`` with keys matching the
+response status code of for each entry. All schema entries should contain descriptions.
+You may also provide a ``default`` response schema to be used if the response doesn't
+match any of the status codes provided.
 
 From our minimalist example:
 
@@ -231,11 +233,13 @@ From our minimalist example:
         body = BodySchema()
 
 
-    # Aggregate the response schemas for out requests
-    class ResponseSchemas(colander.MappingSchema):
-        ok = OkResponseSchema(name='200', description='Return value')
+    # Aggregate the response schemas for get requests
+    response_schemas = {
+        '200': OkResponseSchema(description='Return value')
+    }
 
-    @values.put(response_schemas=PutBodySchema())
+
+    @values.put(response_schemas=response_schemas)
     def set_value(request):
         """Set the value and returns *True* or *False*."""
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -199,7 +199,7 @@ For that you must provide a Response Colander Schema that follows the pattern:
 
 
     get_response_schemas = {
-        '200': ResponseSchema(description='Returns my OK response'),
+        '200': ResponseSchema(description='Return my OK response'),
         '404': ResponseSchema(description='Return my not found response')
     }
 

--- a/examples/minimalist.py
+++ b/examples/minimalist.py
@@ -27,16 +27,17 @@ class OkResponseSchema(colander.MappingSchema):
     body = BodySchema()
 
 
-# Aggregate the response schemas for out requests
-class ResponseSchemas(colander.MappingSchema):
-    ok = OkResponseSchema(name='200', description='Return value')
+# Aggregate the response schemas for get requests
+response_schemas = {
+    '200': OkResponseSchema(description='Return value')
+}
 
 
 # Create our cornice service views
 class MyValueApi(object):
     """My precious API."""
 
-    @values.get(response_schemas=ResponseSchemas())
+    @values.get(response_schemas=response_schemas)
     def get_value(request):
         """Returns the value."""
         key = request.matchdict['value']
@@ -44,7 +45,7 @@ class MyValueApi(object):
 
     @values.put(validators=(colander_body_validator, ),
                 schema=BodySchema(),
-                response_schemas=ResponseSchemas())
+                response_schemas=response_schemas)
     def set_value(request):
         """Set the value and returns *True* or *False*."""
 

--- a/examples/minimalist.py
+++ b/examples/minimalist.py
@@ -1,0 +1,82 @@
+import colander
+from cornice import Service
+from cornice.service import get_services
+from cornice.validators import colander_body_validator
+from wsgiref.simple_server import make_server
+from pyramid.config import Configurator
+from cornice_swagger.swagger import CorniceSwagger
+
+
+_VALUES = {}
+
+
+# Create a simple service that will store and retrieve values
+values = Service(name='foo',
+                 path='/values/{value}',
+                 description="Cornice Demo")
+
+
+# Create a body schema for our requests
+class BodySchema(colander.MappingSchema):
+    value = colander.SchemaNode(colander.String(),
+                                description='My precious value')
+
+
+# Create a response schema for our 200 responses
+class OkResponseSchema(colander.MappingSchema):
+    body = BodySchema()
+
+
+# Aggregate the response schemas for out requests
+class ResponseSchemas(colander.MappingSchema):
+    ok = OkResponseSchema(name='200', description='Return value')
+
+
+# Create our cornice service views
+class MyValueApi(object):
+    """My precious API."""
+
+    @values.get(response_schemas=ResponseSchemas())
+    def get_value(request):
+        """Returns the value."""
+        key = request.matchdict['value']
+        return {'value': _VALUES.get(key)}
+
+    @values.put(validators=(colander_body_validator, ),
+                schema=BodySchema(),
+                response_schemas=ResponseSchemas())
+    def set_value(request):
+        """Set the value and returns *True* or *False*."""
+
+        key = request.matchdict['value']
+        _VALUES[key] = request.json_body
+        return _VALUES.get['key']
+
+
+# Create a service to serve our OpenAPI spec
+swagger = Service(name='OpenAPI',
+                  path='/__api__',
+                  description="OpenAPI documentation")
+
+
+@swagger.get()
+def openAPI_spec(request):
+    my_generator = CorniceSwagger(get_services())
+    my_spec = my_generator('MyAPI', '1.0.0')
+    return my_spec
+
+
+# Setup and run our app
+def setup():
+    config = Configurator()
+    config.include('cornice')
+    config.include('cornice_swagger')
+    config.scan()
+    app = config.make_wsgi_app()
+    return app
+
+
+if __name__ == '__main__':
+    app = setup()
+    server = make_server('127.0.0.1', 8000, app)
+    server.serve_forever()

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,6 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, "README.rst")).read()
 CHANGES = open(os.path.join(here, "CHANGES.rst")).read()
 
-requires = [
-    "cornice",
-    "colander",
-]
-
 REQUIREMENTS = [
     'six',
     'cornice',
@@ -24,12 +19,14 @@ REQUIREMENTS_DEV = [
     'coveralls',
     'flake8',
     'flex',
+    'pyramid',
     'pytest',
     'pytest-cache',
     'pytest-capturelog',
     'pytest-cover',
     'pytest-sugar',
     'tox',
+    'webtest'
 ]
 
 setup(

--- a/tests/support.py
+++ b/tests/support.py
@@ -21,3 +21,23 @@ class HeaderSchema(colander.MappingSchema):
 
 class PathSchema(colander.MappingSchema):
     meh = colander.SchemaNode(colander.String(), default='default')
+
+
+class GetRequestSchema(colander.MappingSchema):
+    querystring = QuerySchema()
+
+
+class PutRequestSchema(colander.MappingSchema):
+    body = BodySchema()
+    querystring = QuerySchema()
+    headers = HeaderSchema()
+
+
+class OkResponseSchema(colander.MappingSchema):
+    body = BodySchema()
+    headers = HeaderSchema()
+
+
+class ResponseSchemas(colander.MappingSchema):
+    ok = OkResponseSchema(name='200', description='Return ice cream')
+    ok = OkResponseSchema(name='200', description='Return sadness')

--- a/tests/support.py
+++ b/tests/support.py
@@ -33,11 +33,12 @@ class PutRequestSchema(colander.MappingSchema):
     headers = HeaderSchema()
 
 
-class OkResponseSchema(colander.MappingSchema):
+class ResponseSchema(colander.MappingSchema):
     body = BodySchema()
     headers = HeaderSchema()
 
 
-class ResponseSchemas(colander.MappingSchema):
-    ok = OkResponseSchema(name='200', description='Return ice cream')
-    ok = OkResponseSchema(name='200', description='Return sadness')
+response_schemas = {
+    '200': ResponseSchema(description='Return ice cream'),
+    '404': ResponseSchema(description='Return sadness')
+}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,7 +6,7 @@ from cornice import Service
 from cornice.validators import colander_validator
 from flex.core import validate
 
-from .support import GetRequestSchema, PutRequestSchema, ResponseSchemas
+from .support import GetRequestSchema, PutRequestSchema, response_schemas
 from cornice_swagger.swagger import CorniceSwagger
 
 
@@ -22,7 +22,7 @@ class AppTest(unittest.TestCase):
 
             @service.get(validators=(colander_validator, ),
                          schema=GetRequestSchema(),
-                         response_schemas=ResponseSchemas())
+                         response_schemas=response_schemas)
             def view_get(self, request):
                 """Serve icecream"""
                 return self.request.validated

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,51 @@
+import unittest
+import webtest
+
+from pyramid import testing
+from cornice import Service
+from cornice.validators import colander_validator
+from flex.core import validate
+
+from .support import GetRequestSchema, PutRequestSchema, ResponseSchemas
+from cornice_swagger.swagger import CorniceSwagger
+
+
+class AppTest(unittest.TestCase):
+
+    def setUp(self):
+        service = Service('IceCream', '/icecream/{flavour}')
+
+        class IceCream(object):
+            """
+            Ice cream service
+            """
+
+            @service.get(validators=(colander_validator, ),
+                         schema=GetRequestSchema(),
+                         response_schemas=ResponseSchemas())
+            def view_get(self, request):
+                """Serve icecream"""
+                return self.request.validated
+
+            @service.put(validators=(colander_validator, ), schema=PutRequestSchema())
+            def view_put(self, request):
+                """Add flavour"""
+                return self.request.validated
+
+        api_service = Service('OpenAPI', '/api')
+
+        @api_service.get()
+        def api_get(request):
+            swagger = CorniceSwagger([service, api_service])
+            return swagger('IceCreamAPI', '4.2')
+
+        self.config = testing.setUp()
+        self.config.include('cornice')
+        self.config.include('cornice_swagger')
+        self.config.add_cornice_service(service)
+        self.config.add_cornice_service(api_service)
+        self.app = webtest.TestApp(self.config.make_wsgi_app())
+
+    def test_validate_spec(self):
+        spec = self.app.get('/api').json
+        validate(spec)

--- a/tests/test_definition_handler.py
+++ b/tests/test_definition_handler.py
@@ -43,7 +43,7 @@ class RefDefinitionTest(unittest.TestCase):
         ref = handler.from_schema(FeelingsSchema(title='Feelings'))
 
         self.assertEquals(ref, {'$ref': '#/definitions/Feelings'})
-        self.assertDictEqual(handler.definitions['Feelings'],
+        self.assertDictEqual(handler.definition_registry['Feelings'],
                              convert(FeelingsSchema(title='Feelings')))
 
     def test_multi_level(self):
@@ -59,7 +59,7 @@ class RefDefinitionTest(unittest.TestCase):
             }
         }
         self.assertDictContainsSubset(feelings_schema,
-                                      handler.definitions['Feelings'])
+                                      handler.definition_registry['Feelings'])
 
         self.assertDictContainsSubset(convert(AnxietySchema()),
-                                      handler.definitions['Aaaa'])
+                                      handler.definition_registry['Aaaa'])

--- a/tests/test_parameter_handler.py
+++ b/tests/test_parameter_handler.py
@@ -174,7 +174,7 @@ class RefParamTest(unittest.TestCase):
         }
 
         self.assertEquals(params, [{'$ref': '#/parameters/id'}])
-        self.assertDictEqual(self.handler.parameters, dict(id=expected))
+        self.assertDictEqual(self.handler.parameter_registry, dict(id=expected))
 
     def test_ref_from_body_validator_schema(self):
         node = BodySchema()
@@ -189,7 +189,7 @@ class RefParamTest(unittest.TestCase):
         }
 
         self.assertEquals(params, [{'$ref': '#/parameters/BodySchema'}])
-        self.assertDictEqual(self.handler.parameters, dict(BodySchema=expected))
+        self.assertDictEqual(self.handler.parameter_registry, dict(BodySchema=expected))
 
     def test_ref_from_request_validator_schema(self):
 
@@ -208,4 +208,4 @@ class RefParamTest(unittest.TestCase):
         }
 
         self.assertEquals(params, [{'$ref': '#/parameters/foo'}])
-        self.assertDictEqual(self.handler.parameters, dict(foo=expected))
+        self.assertDictEqual(self.handler.parameter_registry, dict(foo=expected))

--- a/tests/test_response_handler.py
+++ b/tests/test_response_handler.py
@@ -50,7 +50,7 @@ class RefResponseTest(unittest.TestCase):
             '404': {'$ref': '#/responses/ResponseSchema'}
         }
         self.assertEquals(expected, responses)
-        ref = self.handler.responses['ResponseSchema']
+        ref = self.handler.response_registry['ResponseSchema']
         self.assertDictEqual(ref['schema'],
                              convert_schema(BodySchema(title='BodySchema')))
         self.assertDictEqual(ref['headers'],

--- a/tests/test_response_handler.py
+++ b/tests/test_response_handler.py
@@ -1,0 +1,68 @@
+import unittest
+
+import colander
+
+from cornice_swagger.swagger import ResponseHandler, CorniceSwaggerException
+from cornice_swagger.converters import convert_schema
+from .support import BodySchema, HeaderSchema
+
+
+class ResponseSchema(colander.MappingSchema):
+    body = BodySchema()
+    headers = HeaderSchema()
+
+
+class GetResponses(colander.MappingSchema):
+    ok = ResponseSchema(description='Yaay', name='200')
+    not_found = ResponseSchema(description='Nooo', name='404')
+
+
+class SchemaResponseConversionTest(unittest.TestCase):
+
+    def setUp(self):
+        self.handler = ResponseHandler()
+
+    def test_sanity(self):
+        self.handler.from_schema(GetResponses())
+
+    def test_status_codes(self):
+        responses = self.handler.from_schema(GetResponses())
+        self.assertIn('200', responses)
+        self.assertIn('404', responses)
+        self.assertEquals(responses['200']['description'], 'Yaay')
+        self.assertEquals(responses['404']['description'], 'Nooo')
+
+    def test_response_schema(self):
+        responses = self.handler.from_schema(GetResponses())
+        self.assertDictEqual(responses['200']['schema'],
+                             convert_schema(BodySchema(title='BodySchema')))
+        self.assertDictEqual(responses['200']['headers'],
+                             convert_schema(HeaderSchema())['properties'])
+
+    def test_raise_exception_without_description(self):
+
+        class GetResponses(colander.MappingSchema):
+            ok = ResponseSchema(name='200')
+
+        self.assertRaises(CorniceSwaggerException,
+                          self.handler.from_schema, GetResponses())
+
+
+class RefResponseTest(unittest.TestCase):
+
+    def setUp(self):
+        self.handler = ResponseHandler(ref=1)
+        self.handler.responses = {}
+
+    def test_from_schema(self):
+        responses = self.handler.from_schema(GetResponses())
+        expected = {
+            '200': {'$ref': '#/responses/ResponseSchema'},
+            '404': {'$ref': '#/responses/ResponseSchema'}
+        }
+        self.assertEquals(expected, responses)
+        ref = self.handler.responses['ResponseSchema']
+        self.assertDictEqual(ref['schema'],
+                             convert_schema(BodySchema(title='BodySchema')))
+        self.assertDictEqual(ref['headers'],
+                             convert_schema(HeaderSchema())['properties'])

--- a/tests/test_response_handler.py
+++ b/tests/test_response_handler.py
@@ -1,20 +1,8 @@
 import unittest
 
-import colander
-
 from cornice_swagger.swagger import ResponseHandler, CorniceSwaggerException
 from cornice_swagger.converters import convert_schema
-from .support import BodySchema, HeaderSchema
-
-
-class ResponseSchema(colander.MappingSchema):
-    body = BodySchema()
-    headers = HeaderSchema()
-
-
-class GetResponses(colander.MappingSchema):
-    ok = ResponseSchema(description='Yaay', name='200')
-    not_found = ResponseSchema(description='Nooo', name='404')
+from .support import BodySchema, HeaderSchema, ResponseSchema, response_schemas
 
 
 class SchemaResponseConversionTest(unittest.TestCase):
@@ -23,17 +11,17 @@ class SchemaResponseConversionTest(unittest.TestCase):
         self.handler = ResponseHandler()
 
     def test_sanity(self):
-        self.handler.from_schema(GetResponses())
+        self.handler.from_schema_mapping(response_schemas)
 
     def test_status_codes(self):
-        responses = self.handler.from_schema(GetResponses())
+        responses = self.handler.from_schema_mapping(response_schemas)
         self.assertIn('200', responses)
         self.assertIn('404', responses)
-        self.assertEquals(responses['200']['description'], 'Yaay')
-        self.assertEquals(responses['404']['description'], 'Nooo')
+        self.assertEquals(responses['200']['description'], 'Return ice cream')
+        self.assertEquals(responses['404']['description'], 'Return sadness')
 
     def test_response_schema(self):
-        responses = self.handler.from_schema(GetResponses())
+        responses = self.handler.from_schema_mapping(response_schemas)
         self.assertDictEqual(responses['200']['schema'],
                              convert_schema(BodySchema(title='BodySchema')))
         self.assertDictEqual(responses['200']['headers'],
@@ -41,11 +29,12 @@ class SchemaResponseConversionTest(unittest.TestCase):
 
     def test_raise_exception_without_description(self):
 
-        class GetResponses(colander.MappingSchema):
-            ok = ResponseSchema(name='200')
+        response_schemas = {
+            '200': ResponseSchema()
+        }
 
         self.assertRaises(CorniceSwaggerException,
-                          self.handler.from_schema, GetResponses())
+                          self.handler.from_schema_mapping, response_schemas)
 
 
 class RefResponseTest(unittest.TestCase):
@@ -54,8 +43,8 @@ class RefResponseTest(unittest.TestCase):
         self.handler = ResponseHandler(ref=1)
         self.handler.responses = {}
 
-    def test_from_schema(self):
-        responses = self.handler.from_schema(GetResponses())
+    def test_from_schema_mapping(self):
+        responses = self.handler.from_schema_mapping(response_schemas)
         expected = {
             '200': {'$ref': '#/responses/ResponseSchema'},
             '404': {'$ref': '#/responses/ResponseSchema'}

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -23,7 +23,7 @@ class OkResponseSchema(colander.MappingSchema):
     headers = HeaderSchema()
 
 
-class GetResponseSchema(colander.MappingSchema):
+class GetResponseSchemas(colander.MappingSchema):
     ok = OkResponseSchema(name='200', description='Return icecream')
 
 
@@ -40,7 +40,7 @@ class TestCorniceSwaggerGenerator(unittest.TestCase):
 
             @service.get(validators=(colander_validator, ),
                          schema=GetRequestSchema(),
-                         response_schema=GetResponseSchema())
+                         response_schemas=GetResponseSchemas())
             def view_get(self, request):
                 """Serve icecream"""
                 return self.request.validated
@@ -201,7 +201,7 @@ class NotInstanciatedSchemaTest(unittest.TestCase):
 
             @service.get(validators=(colander_validator, ),
                          schema=GetRequestSchema,
-                         response_schema=GetResponseSchema)
+                         response_schemas=GetResponseSchemas)
             def view_get(self, request):
                 """Serve icecream"""
                 return self.request.validated

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -1,30 +1,11 @@
 import unittest
 
-import colander
 from cornice.validators import colander_validator
 from cornice.service import Service
 from flex.core import validate
 
 from cornice_swagger.swagger import CorniceSwagger
-from .support import BodySchema, QuerySchema, HeaderSchema
-
-
-class GetRequestSchema(colander.MappingSchema):
-    querystring = QuerySchema()
-
-
-class PutRequestSchema(colander.MappingSchema):
-    querystring = QuerySchema()
-    body = BodySchema()
-
-
-class OkResponseSchema(colander.MappingSchema):
-    body = BodySchema()
-    headers = HeaderSchema()
-
-
-class GetResponseSchemas(colander.MappingSchema):
-    ok = OkResponseSchema(name='200', description='Return icecream')
+from .support import GetRequestSchema, PutRequestSchema, ResponseSchemas
 
 
 class TestCorniceSwaggerGenerator(unittest.TestCase):
@@ -40,7 +21,7 @@ class TestCorniceSwaggerGenerator(unittest.TestCase):
 
             @service.get(validators=(colander_validator, ),
                          schema=GetRequestSchema(),
-                         response_schemas=GetResponseSchemas())
+                         response_schemas=ResponseSchemas())
             def view_get(self, request):
                 """Serve icecream"""
                 return self.request.validated
@@ -201,7 +182,7 @@ class NotInstanciatedSchemaTest(unittest.TestCase):
 
             @service.get(validators=(colander_validator, ),
                          schema=GetRequestSchema,
-                         response_schemas=GetResponseSchemas)
+                         response_schemas=ResponseSchemas)
             def view_get(self, request):
                 """Serve icecream"""
                 return self.request.validated

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -3,9 +3,10 @@ import unittest
 import colander
 from cornice.validators import colander_validator
 from cornice.service import Service
+from flex.core import validate
 
 from cornice_swagger.swagger import CorniceSwagger
-from .support import BodySchema, QuerySchema
+from .support import BodySchema, QuerySchema, HeaderSchema
 
 
 class GetRequestSchema(colander.MappingSchema):
@@ -15,6 +16,15 @@ class GetRequestSchema(colander.MappingSchema):
 class PutRequestSchema(colander.MappingSchema):
     querystring = QuerySchema()
     body = BodySchema()
+
+
+class OkResponseSchema(colander.MappingSchema):
+    body = BodySchema()
+    headers = HeaderSchema()
+
+
+class GetResponseSchema(colander.MappingSchema):
+    ok = OkResponseSchema(name='200', description='Return icecream')
 
 
 class TestCorniceSwaggerGenerator(unittest.TestCase):
@@ -28,7 +38,9 @@ class TestCorniceSwaggerGenerator(unittest.TestCase):
             Ice cream service
             """
 
-            @service.get(validators=(colander_validator, ), schema=GetRequestSchema())
+            @service.get(validators=(colander_validator, ),
+                         schema=GetRequestSchema(),
+                         response_schema=GetResponseSchema())
             def view_get(self, request):
                 """Serve icecream"""
                 return self.request.validated
@@ -41,6 +53,7 @@ class TestCorniceSwaggerGenerator(unittest.TestCase):
         self.service = service
         self.swagger = CorniceSwagger([self.service])
         self.spec = self.swagger('IceCreamAPI', '4.2')
+        validate(self.spec)
 
     def test_path(self):
         self.assertIn('/icecream/{flavour}', self.spec['paths'])
@@ -68,6 +81,11 @@ class TestCorniceSwaggerGenerator(unittest.TestCase):
         swagger = CorniceSwagger([self.service], param_ref=True)
         spec = swagger('IceCreamAPI', '4.2')
         self.assertIn('parameters', spec)
+
+    def test_with_resp_ref(self):
+        swagger = CorniceSwagger([self.service], resp_ref=True)
+        spec = swagger('IceCreamAPI', '4.2')
+        self.assertIn('responses', spec)
 
 
 class TestExtractContentTypes(unittest.TestCase):
@@ -169,3 +187,31 @@ class TestExtractContentTypes(unittest.TestCase):
         spec = swagger('IceCreamAPI', '4.2')
         self.assertEquals(spec['paths']['/icecream/{flavour}']['put']['produces'],
                           ['application/json'])
+
+
+class NotInstanciatedSchemaTest(unittest.TestCase):
+
+    def test_not_instanciated(self):
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        class IceCream(object):
+            """
+            Ice cream service
+            """
+
+            @service.get(validators=(colander_validator, ),
+                         schema=GetRequestSchema,
+                         response_schema=GetResponseSchema)
+            def view_get(self, request):
+                """Serve icecream"""
+                return self.request.validated
+
+            @service.put(validators=(colander_validator, ), schema=PutRequestSchema())
+            def view_put(self, request):
+                """Add flavour"""
+                return self.request.validated
+
+        self.service = service
+        self.swagger = CorniceSwagger([self.service])
+        self.spec = self.swagger('IceCreamAPI', '4.2')
+        validate(self.spec)

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -5,7 +5,7 @@ from cornice.service import Service
 from flex.core import validate
 
 from cornice_swagger.swagger import CorniceSwagger
-from .support import GetRequestSchema, PutRequestSchema, ResponseSchemas
+from .support import GetRequestSchema, PutRequestSchema, response_schemas
 
 
 class TestCorniceSwaggerGenerator(unittest.TestCase):
@@ -21,7 +21,7 @@ class TestCorniceSwaggerGenerator(unittest.TestCase):
 
             @service.get(validators=(colander_validator, ),
                          schema=GetRequestSchema(),
-                         response_schemas=ResponseSchemas())
+                         response_schemas=response_schemas)
             def view_get(self, request):
                 """Serve icecream"""
                 return self.request.validated
@@ -182,8 +182,7 @@ class NotInstantiatedSchemaTest(unittest.TestCase):
 
             # Use GetRequestSchema and ResponseSchemas classes instead of objects
             @service.get(validators=(colander_validator, ),
-                         schema=GetRequestSchema,
-                         response_schemas=ResponseSchemas)
+                         schema=GetRequestSchema)
             def view_get(self, request):
                 """Serve icecream"""
                 return self.request.validated

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -170,7 +170,7 @@ class TestExtractContentTypes(unittest.TestCase):
                           ['application/json'])
 
 
-class NotInstanciatedSchemaTest(unittest.TestCase):
+class NotInstantiatedSchemaTest(unittest.TestCase):
 
     def test_not_instanciated(self):
         service = Service("IceCream", "/icecream/{flavour}")
@@ -180,6 +180,7 @@ class NotInstanciatedSchemaTest(unittest.TestCase):
             Ice cream service
             """
 
+            # Use GetRequestSchema and ResponseSchemas classes instead of objects
             @service.get(validators=(colander_validator, ),
                          schema=GetRequestSchema,
                          response_schemas=ResponseSchemas)

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -172,7 +172,7 @@ class TestExtractContentTypes(unittest.TestCase):
 
 class NotInstantiatedSchemaTest(unittest.TestCase):
 
-    def test_not_instanciated(self):
+    def test_not_instantiated(self):
         service = Service("IceCream", "/icecream/{flavour}")
 
         class IceCream(object):

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ commands =
     py.test --cov-report term-missing --cov cornice_swagger
     coverage report -m
 deps =
-    pytest
     -rrequirements.txt
     -rdev-requirements.txt
 


### PR DESCRIPTION
- [x] Allow extra kwargs on pyramid
- [x] Update documentation

This way one can document responses using:

```python
class DefaultResponseSchema(colander.MappingSchema):
    body = BodySchema()
    headers = HeaderSchema()


get_response_schemas = {
    '200': DefaultResponseSchema(description='Yaay'),
    '404': DefaultResponseSchema(description='Nooo')
}


service = Service("IceCream", "/icecream/{flavour}")


@service.get(response_schemas=get_response_schemas)
def view_get(self, request):
    """Serve icecream"""
    return BodySchema.serialize()
```

r? @leplatrem @glasserc 

Edit: thinking thorough it maybe using dictionaries to aggregate response schemas may be a better idea than using another colander mapping.  