### PR TITLE
Change how tags are documented (fixes #25)

### DIFF
--- a/cornice_swagger/__init__.py
+++ b/cornice_swagger/__init__.py
@@ -3,7 +3,7 @@ __email__ = 'delicj@delijati.net'
 __version__ = '0.3.0'
 
 
-class ResponseSchemaPredicate(object):
+class CorniceSwaggerPredicate(object):
     def __init__(self, schema, config):
         self.schema = schema
 
@@ -12,4 +12,5 @@ class ResponseSchemaPredicate(object):
 
 
 def includeme(config):
-    config.add_view_predicate('response_schemas', ResponseSchemaPredicate)
+    config.add_view_predicate('response_schemas', CorniceSwaggerPredicate)
+    config.add_view_predicate('tags', CorniceSwaggerPredicate)

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -56,9 +56,6 @@ The resulting `swagger.json` at `http://localhost:8000/__api__` is:
         "tags": [
             {
                 "name": "values"
-            },
-            {
-                "name": "__api__"
             }
         ]
         "paths": {
@@ -152,9 +149,6 @@ The resulting `swagger.json` at `http://localhost:8000/__api__` is:
             },
             "/__api__": {
                 "get": {
-                    "tags": [
-                        "__api__"
-                    ],
                     "responses": {
                         "default": {
                             "description": "UNDOCUMENTED RESPONSE"

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -273,3 +273,62 @@ From our minimalist example:
             }
         }
     }
+
+
+Documenting tags
+================
+
+Cornice Swagger supports two ways of documenting operation tags. You can either
+provide a list of tags on the view decorator or have a ``default_tags``
+attribute when calling the generator.
+
+
+.. code-block:: python
+
+    values = Service(name='foo',
+                     path='/values/{value}')
+
+    @values.put(tags=['value'])
+    def set_value(request):
+        """Set the value and returns *True* or *False*."""
+
+
+.. code-block:: json
+
+    {
+        "tags": [
+            {
+                "name": "values"
+            }
+        ],
+        "paths": {
+            "/values/{value}": {
+                "get": {
+                    "tags": [
+                        "values"
+                    ]
+                }
+            }
+        }
+    }
+
+
+When using the ``default_tags`` attribute, you can either use a raw list
+of tags or a callable that takes a cornice service and returns a list of tags.
+
+
+.. code-block:: python
+
+    def default_tag_callable(service):
+        return [service.path.split('/')[1]]
+
+    swagger = CorniceSwagger(get_services())
+    spec = swagger('IceCreamAPI', '4.2',
+                   default_tags=default_tag_callable)
+
+.. code-block:: python
+
+    swagger = CorniceSwagger(get_services())
+    spec = swagger('IceCreamAPI', '4.2',
+                   default_tags=['MyAPI'])
+

--- a/examples/minimalist.py
+++ b/examples/minimalist.py
@@ -37,15 +37,14 @@ response_schemas = {
 class MyValueApi(object):
     """My precious API."""
 
-    @values.get(response_schemas=response_schemas)
+    @values.get(tags=['values'], response_schemas=response_schemas)
     def get_value(request):
         """Returns the value."""
         key = request.matchdict['value']
         return {'value': _VALUES.get(key)}
 
-    @values.put(validators=(colander_body_validator, ),
-                schema=BodySchema(),
-                response_schemas=response_schemas)
+    @values.put(tags=['values'], validators=(colander_body_validator, ),
+                schema=BodySchema(), response_schemas=response_schemas)
     def set_value(request):
         """Set the value and returns *True* or *False*."""
 


### PR DESCRIPTION
Fixes #25 

Allow adding tags from view decorators of via a `default_tags` attribute when calling the generator. 

r? @glasserc 