### PR TITLE
fix response header schema name to match cornice requests

### DIFF
--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -459,7 +459,7 @@ class ResponseHandler(object):
                 if location == 'body':
                     field_schema.title = field_schema.__class__.__name__
                     response['schema'] = self.definitions.from_schema(field_schema)
-                elif location == 'headers':
+                elif location == 'header':
                     headers = convert_schema(field_schema)
                     if 'properties' in headers:
                         response['headers'] = headers['properties']

--- a/tests/support.py
+++ b/tests/support.py
@@ -16,7 +16,7 @@ class QuerySchema(colander.MappingSchema):
 
 
 class HeaderSchema(colander.MappingSchema):
-    bar = colander.SchemaNode(colander.String())
+    bar = colander.SchemaNode(colander.String(), missing=colander.drop)
 
 
 class PathSchema(colander.MappingSchema):
@@ -30,12 +30,12 @@ class GetRequestSchema(colander.MappingSchema):
 class PutRequestSchema(colander.MappingSchema):
     body = BodySchema()
     querystring = QuerySchema()
-    headers = HeaderSchema()
+    header = HeaderSchema()
 
 
 class ResponseSchema(colander.MappingSchema):
     body = BodySchema()
-    headers = HeaderSchema()
+    header = HeaderSchema()
 
 
 response_schemas = {

--- a/tests/test_parameter_handler.py
+++ b/tests/test_parameter_handler.py
@@ -85,7 +85,7 @@ class SchemaParamConversionTest(unittest.TestCase):
             'name': 'bar',
             'in': 'header',
             'type': 'string',
-            'required': True,
+            'required': False,
         }
         self.assertDictEqual(params[0], expected)
 


### PR DESCRIPTION
Change `headers` to `header` on the response schema.

Also add add tests to check if the app is working properly.