### PR TITLE
Include parameters `items` field

### DIFF
--- a/cornice_swagger/converters/parameters.py
+++ b/cornice_swagger/converters/parameters.py
@@ -24,10 +24,15 @@ class ParameterConverter(object):
 
         schema = definition_handler(schema_node)
 
-        if '$ref' in schema or schema['type'] == 'object':
+        if '$ref' in schema or schema.get('type') == 'object':
             converted['schema'] = schema
         else:
             converted['type'] = schema['type']
+
+        if schema.get('type') == 'array':
+            converted['items'] = {}
+            converted['items']['type'] = schema['items']['type']
+
         return converted
 
 

--- a/tests/converters/test_parameters.py
+++ b/tests/converters/test_parameters.py
@@ -28,6 +28,21 @@ class ParameterConversionTest(unittest.TestCase):
             'required': True,
         })
 
+    def test_query_array(self):
+
+        class MyArray(colander.SequenceSchema):
+            values = colander.SchemaNode(colander.String())
+
+        node = MyArray(name='bar')
+        ret = convert_parameter('querystring', node)
+        self.assertDictEqual(ret, {
+            'in': 'query',
+            'name': 'bar',
+            'type': 'array',
+            'items': {'type': 'string'},
+            'required': True,
+        })
+
     def test_header(self):
         node = colander.SchemaNode(colander.String(), name='meh')
         ret = convert_parameter('headers', node)


### PR DESCRIPTION
include missing `items` field when using arrays on query/header parameters.