### PR TITLE
Colander declarative schemas handling

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -3,4 +3,4 @@ Alphabetically-ordered List of the people who contributed to Cornice Swagger:
 - Gabriela Surita <gsurita@mozilla.com>
 - Jason Haury
 - Josip Delic
-
+- Simone Marzola <marzolasimone@gmail.com>

--- a/cornice_swagger/converters/parameters.py
+++ b/cornice_swagger/converters/parameters.py
@@ -24,10 +24,15 @@ class ParameterConverter(object):
 
         schema = definition_handler(schema_node)
 
-        if '$ref' in schema or schema['type'] == 'object':
+        if '$ref' in schema or schema.get('type') == 'object':
             converted['schema'] = schema
         else:
             converted['type'] = schema['type']
+
+        if schema.get('type') == 'array':
+            converted['items'] = {}
+            converted['items']['type'] = schema['items']['type']
+
         return converted
 
 

--- a/cornice_swagger/converters/parameters.py
+++ b/cornice_swagger/converters/parameters.py
@@ -23,15 +23,10 @@ class ParameterConverter(object):
             converted['default'] = schema_node.default
 
         schema = definition_handler(schema_node)
-
-        if '$ref' in schema or schema.get('type') == 'object':
-            converted['schema'] = schema
-        else:
-            converted['type'] = schema['type']
+        converted['type'] = schema['type']
 
         if schema.get('type') == 'array':
-            converted['items'] = {}
-            converted['items']['type'] = schema['items']['type']
+            converted['items'] = {'type': schema['items']['type']}
 
         return converted
 
@@ -52,9 +47,18 @@ class BodyParameterConverter(ParameterConverter):
     _in = 'body'
 
     def convert(self, schema_node, definition_handler):
+
+        converted = {
+            'name': schema_node.name,
+            'in': self._in,
+            'required': schema_node.required
+        }
+        if schema_node.description:
+            converted['description'] = schema_node.description
+
         schema_node.title = schema_node.__class__.__name__
-        converted = super(BodyParameterConverter, self).convert(schema_node,
-                                                                definition_handler)
+        schema = definition_handler(schema_node)
+        converted['schema'] = schema
 
         return converted
 

--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -356,8 +356,8 @@ class ParameterHandler(object):
             location = param_schema.name
             if location is 'body':
                 name = param_schema.__class__.__name__
-                if name == location:
-                    name = schema_node.__class__.__name__ + location.title()
+                if name == 'body':
+                    name = schema_node.__class__.__name__ + 'Body'
                 param = convert_parameter(location,
                                           param_schema,
                                           partial(self.definitions.from_schema, base_name=name))
@@ -458,7 +458,11 @@ class ResponseHandler(object):
             for field_schema in response_schema.children:
                 location = field_schema.name
                 if location == 'body':
-                    field_schema.title = field_schema.__class__.__name__
+                    title = field_schema.__class__.__name__
+                    if title == 'body':
+                        title = response_schema.__class__.__name__ + 'Body'
+                    field_schema.title = title
+
                     response['schema'] = self.definitions.from_schema(field_schema)
                 elif location == 'header':
                     headers = convert_schema(field_schema)

--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -5,7 +5,7 @@ from functools import partial
 import six
 
 import colander
-from cornice.validators import colander_validator, colander_body_validator
+from cornice.validators import colander_body_validator
 
 import cornice_swagger.util
 from cornice_swagger.converters import convert_schema, convert_parameter

--- a/cornice_swagger/util.py
+++ b/cornice_swagger/util.py
@@ -1,4 +1,6 @@
+import colander
 import six
+from cornice.validators import colander_body_validator
 
 
 def trim(docstring):
@@ -16,3 +18,12 @@ def trim(docstring):
     lines = [line.strip() for line in lines]
     res = six.u('\n').join(lines)
     return res
+
+
+def body_schema_transformer(schema, args):
+    validators = args.get('validators', [])
+    if colander_body_validator in validators:
+        body_schema = schema
+        schema = colander.MappingSchema()
+        schema['body'] = body_schema
+    return schema

--- a/tests/converters/test_parameters.py
+++ b/tests/converters/test_parameters.py
@@ -53,6 +53,20 @@ class ParameterConversionTest(unittest.TestCase):
             'required': True,
         })
 
+    def test_body_array(self):
+
+        class MyArray(colander.SequenceSchema):
+            values = colander.SchemaNode(colander.String())
+
+        node = MyArray(name='bla')
+        ret = convert_parameter('body', node)
+        self.assertDictEqual(ret, {
+            'in': 'body',
+            'name': 'bla',
+            'required': True,
+            'schema': convert_schema(MyArray(title='MyArray')),
+        })
+
     def test_body(self):
 
         class MyBody(colander.MappingSchema):

--- a/tests/converters/test_parameters.py
+++ b/tests/converters/test_parameters.py
@@ -28,6 +28,21 @@ class ParameterConversionTest(unittest.TestCase):
             'required': True,
         })
 
+    def test_query_array(self):
+
+        class MyArray(colander.SequenceSchema):
+            values = colander.SchemaNode(colander.String())
+
+        node = MyArray(name='bar')
+        ret = convert_parameter('querystring', node)
+        self.assertDictEqual(ret, {
+            'in': 'query',
+            'name': 'bar',
+            'type': 'array',
+            'items': {'type': 'string'},
+            'required': True,
+        })
+
     def test_header(self):
         node = colander.SchemaNode(colander.String(), name='meh')
         ret = convert_parameter('headers', node)

--- a/tests/support.py
+++ b/tests/support.py
@@ -42,3 +42,15 @@ response_schemas = {
     '200': ResponseSchema(description='Return ice cream'),
     '404': ResponseSchema(description='Return sadness')
 }
+
+
+class DeclarativeSchema(colander.MappingSchema):
+    @colander.instantiate(description='my body')
+    class body(colander.MappingSchema):
+        id = colander.SchemaNode(colander.String())
+
+
+class AnotherDeclarativeSchema(colander.MappingSchema):
+    @colander.instantiate(description='my another body')
+    class body(colander.MappingSchema):
+        timestamp = colander.SchemaNode(colander.Int())

--- a/tests/test_parameter_handler.py
+++ b/tests/test_parameter_handler.py
@@ -4,7 +4,7 @@ import colander
 
 from cornice.validators import colander_validator, colander_body_validator
 
-from cornice_swagger.swagger import ParameterHandler
+from cornice_swagger.swagger import ParameterHandler, DefinitionHandler
 from cornice_swagger.converters import convert_schema
 from .support import BodySchema, PathSchema, QuerySchema, HeaderSchema
 
@@ -142,6 +142,24 @@ class SchemaParamConversionTest(unittest.TestCase):
         }
 
         self.assertDictEqual(params[0], expected)
+
+    def test_declarative_schema_handling(self):
+        class RequestSchema(colander.MappingSchema):
+            @colander.instantiate(description='my body')
+            class body(colander.MappingSchema):
+                id = colander.SchemaNode(colander.String())
+
+        class AnotherRequestSchema(colander.MappingSchema):
+            @colander.instantiate(description='my another body')
+            class body(colander.MappingSchema):
+                timestamp = colander.SchemaNode(colander.Int())
+
+        validators = [colander_validator]
+        handler = ParameterHandler(DefinitionHandler(ref=-1))
+        params = handler.from_schema(RequestSchema(), validators)
+        another_params = handler.from_schema(AnotherRequestSchema(), validators)
+
+        self.assertNotEqual(params[0]['schema'], another_params[0]['schema'])
 
 
 class PathParamConversionTest(unittest.TestCase):

--- a/tests/test_parameter_handler.py
+++ b/tests/test_parameter_handler.py
@@ -209,6 +209,18 @@ class RefParamTest(unittest.TestCase):
         self.assertEquals(params, [{'$ref': '#/parameters/BodySchema'}])
         self.assertDictEqual(self.handler.parameter_registry, dict(BodySchema=expected))
 
+    def test_ref_from_declarative_body_validator_schema(self):
+        class DeclarativeSchema(colander.MappingSchema):
+            @colander.instantiate()
+            class body(colander.MappingSchema):
+                id = colander.SchemaNode(colander.String())
+                timestamp = colander.SchemaNode(colander.Int())
+
+        validators = [colander_body_validator]
+        params = self.handler.from_schema(DeclarativeSchema()['body'], validators)
+
+        self.assertEquals([{'$ref': '#/parameters/SchemaBody'}], params)
+
     def test_ref_from_request_validator_schema(self):
 
         class RequestSchema(colander.MappingSchema):

--- a/tests/test_parameter_handler.py
+++ b/tests/test_parameter_handler.py
@@ -6,7 +6,12 @@ from cornice.validators import colander_validator, colander_body_validator
 
 from cornice_swagger.swagger import ParameterHandler, DefinitionHandler
 from cornice_swagger.converters import convert_schema
-from .support import BodySchema, PathSchema, QuerySchema, HeaderSchema
+from .support import (BodySchema,
+                      PathSchema,
+                      QuerySchema,
+                      HeaderSchema,
+                      DeclarativeSchema,
+                      AnotherDeclarativeSchema)
 
 
 class SchemaParamConversionTest(unittest.TestCase):
@@ -144,20 +149,10 @@ class SchemaParamConversionTest(unittest.TestCase):
         self.assertDictEqual(params[0], expected)
 
     def test_declarative_schema_handling(self):
-        class RequestSchema(colander.MappingSchema):
-            @colander.instantiate(description='my body')
-            class body(colander.MappingSchema):
-                id = colander.SchemaNode(colander.String())
-
-        class AnotherRequestSchema(colander.MappingSchema):
-            @colander.instantiate(description='my another body')
-            class body(colander.MappingSchema):
-                timestamp = colander.SchemaNode(colander.Int())
-
         validators = [colander_validator]
         handler = ParameterHandler(DefinitionHandler(ref=-1))
-        params = handler.from_schema(RequestSchema(), validators)
-        another_params = handler.from_schema(AnotherRequestSchema(), validators)
+        params = handler.from_schema(DeclarativeSchema(), validators)
+        another_params = handler.from_schema(AnotherDeclarativeSchema(), validators)
 
         self.assertNotEqual(params[0]['schema'], another_params[0]['schema'])
 
@@ -210,12 +205,6 @@ class RefParamTest(unittest.TestCase):
         self.assertDictEqual(self.handler.parameter_registry, dict(BodySchema=expected))
 
     def test_ref_from_declarative_body_validator_schema(self):
-        class DeclarativeSchema(colander.MappingSchema):
-            @colander.instantiate()
-            class body(colander.MappingSchema):
-                id = colander.SchemaNode(colander.String())
-                timestamp = colander.SchemaNode(colander.Int())
-
         validators = [colander_body_validator]
         params = self.handler.from_schema(DeclarativeSchema()['body'], validators)
 

--- a/tests/test_response_handler.py
+++ b/tests/test_response_handler.py
@@ -2,12 +2,8 @@ import unittest
 
 from cornice_swagger.swagger import ResponseHandler, CorniceSwaggerException
 from cornice_swagger.converters import convert_schema
-from .support import (BodySchema,
-                      HeaderSchema,
-                      ResponseSchema,
-                      response_schemas,
-                      DeclarativeSchema,
-                      AnotherDeclarativeSchema)
+from .support import BodySchema, HeaderSchema, ResponseSchema, response_schemas,\
+    DeclarativeSchema, AnotherDeclarativeSchema
 
 
 class SchemaResponseConversionTest(unittest.TestCase):

--- a/tests/test_response_handler.py
+++ b/tests/test_response_handler.py
@@ -1,10 +1,13 @@
 import unittest
 
-import colander
-
 from cornice_swagger.swagger import ResponseHandler, CorniceSwaggerException
 from cornice_swagger.converters import convert_schema
-from .support import BodySchema, HeaderSchema, ResponseSchema, response_schemas
+from .support import (BodySchema,
+                      HeaderSchema,
+                      ResponseSchema,
+                      response_schemas,
+                      DeclarativeSchema,
+                      AnotherDeclarativeSchema)
 
 
 class SchemaResponseConversionTest(unittest.TestCase):
@@ -59,25 +62,16 @@ class RefResponseTest(unittest.TestCase):
                              convert_schema(HeaderSchema())['properties'])
 
     def test_declarative_response_schemas(self):
-        class ResponseSchema(colander.MappingSchema):
-            @colander.instantiate()
-            class body(colander.MappingSchema):
-                timestamp = colander.SchemaNode(colander.Int())
-
-        class AnotherResponseSchema(colander.MappingSchema):
-            @colander.instantiate()
-            class body(colander.MappingSchema):
-                timestamp = colander.SchemaNode(colander.Int())
 
         self.handler.from_schema_mapping({
-            '200': ResponseSchema(description='response schema')
+            '200': DeclarativeSchema(description='response schema')
         })
 
         self.handler.from_schema_mapping({
-            '200': AnotherResponseSchema(description='response schema')
+            '200': AnotherDeclarativeSchema(description='response schema')
         })
 
-        ref = self.handler.response_registry['ResponseSchema']
-        another_ref = self.handler.response_registry['AnotherResponseSchema']
+        ref = self.handler.response_registry['DeclarativeSchema']
+        another_ref = self.handler.response_registry['AnotherDeclarativeSchema']
 
         self.assertNotEqual(ref['schema']['title'], another_ref['schema']['title'])


### PR DESCRIPTION
When colander declarative schemas with `@instantiate` decorator are used, eg
```python
class DeclarativeSchema(colander.MappingSchema):
    @colander.instantiate(description='my body')
    class body(colander.MappingSchema):
        id = colander.SchemaNode(colander.String())
        timestamp = colander.SchemaNode(colander.Int())
```
schema names and refs collide and only one schema is used for all the services.

This pull request fixes this behaviour.

I've also refactored `ParameterHandler.from_schema`, removing repeated code. I'm still not happy that the method has to be aware of the validators, but all the solution I've in mind involve breaking changes to the api, so I left them :)