### PR TITLE
Support for custom type dispatcher

### DIFF
--- a/cornice_swagger/converters/__init__.py
+++ b/cornice_swagger/converters/__init__.py
@@ -7,11 +7,8 @@ from cornice_swagger.converters.schema import TypeConversionDispatcher
 from cornice_swagger.converters.parameters import ParameterConversionDispatcher
 
 
-def convert_schema(schema_node):
-
-    dispatcher = TypeConversionDispatcher()
+def convert_schema(schema_node, dispatcher=TypeConversionDispatcher()):
     converted = dispatcher(schema_node)
-
     return converted
 
 

--- a/cornice_swagger/converters/schema.py
+++ b/cornice_swagger/converters/schema.py
@@ -237,24 +237,28 @@ class ArrayTypeConverter(TypeConverter):
 
 class TypeConversionDispatcher(object):
 
-    converters = {
-        colander.Boolean: BooleanTypeConverter,
-        colander.Date: DateTypeConverter,
-        colander.DateTime: DateTimeTypeConverter,
-        colander.Float: NumberTypeConverter,
-        colander.Integer: IntegerTypeConverter,
-        colander.Mapping: ObjectTypeConverter,
-        colander.Sequence: ArrayTypeConverter,
-        colander.String: StringTypeConverter,
-        colander.Time: TimeTypeConverter,
-    }
+    def __init__(self, custom_converters=None, default_converter=None):
+        self.converters = {
+            colander.Boolean: BooleanTypeConverter,
+            colander.Date: DateTypeConverter,
+            colander.DateTime: DateTimeTypeConverter,
+            colander.Float: NumberTypeConverter,
+            colander.Integer: IntegerTypeConverter,
+            colander.Mapping: ObjectTypeConverter,
+            colander.Sequence: ArrayTypeConverter,
+            colander.String: StringTypeConverter,
+            colander.Time: TimeTypeConverter,
+        }
+        if custom_converters:
+            self.converters.update(custom_converters)
+        self.default_converter = default_converter
 
     def __call__(self, schema_node):
 
         schema_type = schema_node.typ
         schema_type = type(schema_type)
 
-        converter_class = self.converters.get(schema_type)
+        converter_class = self.converters.get(schema_type, self.default_converter)
         if converter_class is None:
             raise NoSuchConverter
 

--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -10,9 +10,6 @@ from cornice_swagger.converters import TypeConversionDispatcher
 from cornice_swagger.converters import convert_schema, convert_parameter
 
 
-_default = object()
-
-
 class CorniceSwaggerException(Exception):
     """Raised when cornice services have structural problems to be converted."""
 
@@ -21,7 +18,7 @@ class CorniceSwagger(object):
     """Handles the creation of a swagger document from a cornice application."""
 
     def __init__(self, services, def_ref_depth=0, param_ref=False, resp_ref=False,
-                 typ_dispatcher=_default):
+                 custom_type_converters=None, default_type_converter=None):
         """
         :param services:
             List of cornice services to document. You may use
@@ -41,10 +38,8 @@ class CorniceSwagger(object):
         """
 
         self.services = services
-        def_handler_args = {'ref': def_ref_depth}
-        if typ_dispatcher is not _default:
-            def_handler_args['typ_dispatcher'] = typ_dispatcher
-        self.definitions = DefinitionHandler(**def_handler_args)
+        typ_dispatcher = TypeConversionDispatcher(custom_type_converters, default_type_converter)
+        self.definitions = DefinitionHandler(ref=def_ref_depth, typ_dispatcher=typ_dispatcher)
         self.parameters = ParameterHandler(self.definitions,
                                            ref=param_ref)
         self.responses = ResponseHandler(self.definitions,

--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -35,6 +35,13 @@ class CorniceSwagger(object):
             Defines if swagger responses should be put inline on the operation
             or on the responses section and referenced by JSON pointers.
             Default is inline.
+        :param custom_type_converters:
+            A dictionary mapping user defined cornice types to callables
+            implementing cornice_swagger.converters.schema.TypeConverter iface
+        :param default_type_converter:
+            Default TypeConverter to use when there is no type registered for a
+            cornice type. If it's not given and the type is not registered,
+            cornice_swagger.converters.exceptions.NoSuchConverter is raised
         """
 
         self.services = services

--- a/tests/support.py
+++ b/tests/support.py
@@ -54,3 +54,11 @@ class AnotherDeclarativeSchema(colander.MappingSchema):
     @colander.instantiate(description='my another body')
     class body(colander.MappingSchema):
         timestamp = colander.SchemaNode(colander.Int())
+
+
+class MyType(colander.String):
+    pass
+
+
+class CustomTypeQuerySchema(colander.MappingSchema):
+    foo = colander.SchemaNode(MyType(), missing=colander.drop)

--- a/tests/test_parameter_handler.py
+++ b/tests/test_parameter_handler.py
@@ -59,13 +59,27 @@ class SchemaParamConversionTest(unittest.TestCase):
         self.assertDictEqual(params[0], expected)
 
     def test_covert_query_with_custom_colander_type(self):
+        converters = {MyType: StringTypeConverter}
+        typ_dispatcher = TypeConversionDispatcher(custom_converters=converters)
+        definition_handler = DefinitionHandler(typ_dispatcher=typ_dispatcher)
 
-        class MyTypeDispatcher(TypeConversionDispatcher):
-            converters = {
-                MyType: StringTypeConverter
-            }
+        class RequestSchema(colander.MappingSchema):
+            querystring = CustomTypeQuerySchema()
 
-        typ_dispatcher = MyTypeDispatcher()
+        node = RequestSchema()
+        params = ParameterHandler(definition_handler).from_schema(node)
+        self.assertEquals(len(params), 1)
+
+        expected = {
+            'name': 'foo',
+            'in': 'query',
+            'type': 'string',
+            'required': False
+        }
+        self.assertDictEqual(params[0], expected)
+
+    def test_covert_query_with_default_colander_type(self):
+        typ_dispatcher = TypeConversionDispatcher(default_converter=StringTypeConverter)
         definition_handler = DefinitionHandler(typ_dispatcher=typ_dispatcher)
 
         class RequestSchema(colander.MappingSchema):

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -65,6 +65,14 @@ class TestCorniceSwaggerGenerator(unittest.TestCase):
         spec = swagger('IceCreamAPI', '4.2')
         self.assertIn('responses', spec)
 
+    def test_using_provided_type_dispatcher(self):
+        # todo: improve testing by mocking definitions and ensure that .convert_schema is called
+        no_typ_dispatcher = object()
+        swagger = CorniceSwagger([], typ_dispatcher=no_typ_dispatcher)
+        self.assertEqual(no_typ_dispatcher, swagger.definitions.typ_dispatcher)
+        self.assertEqual(no_typ_dispatcher, swagger.parameters.definitions.typ_dispatcher)
+        self.assertEqual(no_typ_dispatcher, swagger.responses.definitions.typ_dispatcher)
+
 
 class TestExtractContentTypes(unittest.TestCase):
 

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -65,13 +65,13 @@ class TestCorniceSwaggerGenerator(unittest.TestCase):
         spec = swagger('IceCreamAPI', '4.2')
         self.assertIn('responses', spec)
 
-    def test_using_provided_type_dispatcher(self):
+    def test_using_provided_dispatcher_params(self):
         # todo: improve testing by mocking definitions and ensure that .convert_schema is called
-        no_typ_dispatcher = object()
-        swagger = CorniceSwagger([], typ_dispatcher=no_typ_dispatcher)
-        self.assertEqual(no_typ_dispatcher, swagger.definitions.typ_dispatcher)
-        self.assertEqual(no_typ_dispatcher, swagger.parameters.definitions.typ_dispatcher)
-        self.assertEqual(no_typ_dispatcher, swagger.responses.definitions.typ_dispatcher)
+        default_typ = object()
+        swagger = CorniceSwagger([], custom_type_converters={default_typ: default_typ},
+                                 default_type_converter=default_typ)
+        self.assertIn(default_typ, swagger.definitions.typ_dispatcher.converters)
+        self.assertEqual(default_typ, swagger.definitions.typ_dispatcher.default_converter)
 
 
 class TestExtractContentTypes(unittest.TestCase):


### PR DESCRIPTION
Is not uncommon to extend colander by defining new types, but `cornice.ext.swagger` did not provide an easy way to support custom types (in fact you had to monkey patch the library to achieve this).

I've addressed this issue by allowing a custom type dispatcher to be passed to the Swagger constructor.