### PR TITLE
Merge swagger param with extract values

### DIFF
--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -80,8 +80,8 @@ class CorniceSwagger(object):
         # Update the provided tags with the extracted ones preserving order
         if tags:
             swagger.setdefault('tags', [])
+            tag_names = {t['name'] for t in swagger['tags']}
             for tag in tags:
-                tag_names = [t['name'] for t in swagger['tags']]
                 if tag['name'] not in tag_names:
                     swagger['tags'].append(tag)
 

--- a/cornice_swagger/util.py
+++ b/cornice_swagger/util.py
@@ -27,3 +27,16 @@ def body_schema_transformer(schema, args):
         schema = colander.MappingSchema()
         schema['body'] = body_schema
     return schema
+
+
+def merge_dicts(base, changes):
+    """Merge b into a recursively, without overwriting values.
+
+    :param base: the dict that will be altered.
+    :param changes: changes to update base.
+    """
+    for k, v in changes.items():
+        if isinstance(v, dict):
+            merge_dicts(base.setdefault(k, {}), v)
+        else:
+            base.setdefault(k, v)

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -280,6 +280,20 @@ class TestExtractTags(unittest.TestCase):
         tags = spec['paths']['/icecream/{flavour}']['get']['tags']
         self.assertEquals(tags, ['cold'])
 
+    def test_tags_sorting(self):
+
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        class IceCream(object):
+            @service.get(tags=['cold', 'foo'])
+            def view_get(self, request):
+                return service
+
+        swagger = CorniceSwagger([service])
+        spec = swagger('IceCreamAPI', '4.2', tags_order=['foo'])
+        validate(spec)
+        self.assertListEqual([{'name': 'foo'}, {'name': 'cold'}], spec['tags'])
+
     def test_invalid_tag_raises_exception(self):
 
         service = Service("IceCream", "/icecream/{flavour}")

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -71,7 +71,7 @@ class TestCorniceSwaggerGenerator(unittest.TestCase):
     def test_swagger_field_updates_extracted_paths(self):
         swagger = CorniceSwagger([self.service])
         raw_swagger = {
-            'definitions': {'OtherDef':{'additionalProperties': {}}}
+            'definitions': {'OtherDef': {'additionalProperties': {}}}
         }
         spec = swagger('IceCreamAPI', '4.2', swagger=raw_swagger)
         validate(self.spec)
@@ -86,6 +86,7 @@ class TestCorniceSwaggerGenerator(unittest.TestCase):
         validate(self.spec)
         expected = {'name': 'BodySchema', 'required': False}
         self.assertDictContainsSubset(expected, spec['parameters']['BodySchema'])
+
 
 class TestExtractContentTypes(unittest.TestCase):
 


### PR DESCRIPTION
Related to #47

Recursively merge the fields provided on swagger parameter instead of replacing with the extracted ones. 

Features:
- Update tag descriptions and override order while keeping the missing ones.
- Allow diff changes to the extracted document using raw swagger.

r? @smarzola 