### PR TITLE
add support for cornice schema location synonyms 

### DIFF
--- a/cornice_swagger/converters/parameters.py
+++ b/cornice_swagger/converters/parameters.py
@@ -69,6 +69,8 @@ class ParameterConversionDispatcher(object):
         'body': BodyParameterConverter,
         'path': PathParameterConverter,
         'querystring': QueryParameterConverter,
+        'GET': QueryParameterConverter,
+        'header': HeaderParameterConverter,
         'headers': HeaderParameterConverter,
     }
 

--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -415,7 +415,7 @@ class ParameterHandler(object):
                     param = self._ref(param)
                 params.append(param)
 
-            elif location in ('path', 'headers', 'querystring'):
+            elif location in (('path', 'header', 'headers', 'querystring', 'GET')):
                 for node_schema in param_schema.children:
                     param = convert_parameter(location,
                                               node_schema,

--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -514,7 +514,7 @@ class ResponseHandler(object):
                     field_schema.title = title
                     response['schema'] = self.definitions.from_schema(field_schema)
 
-                elif location == 'header':
+                elif location in ('header', 'headers'):
                     header_schema = convert_schema(field_schema)
                     headers = header_schema.get('properties')
                     if headers:

--- a/tests/test_parameter_handler.py
+++ b/tests/test_parameter_handler.py
@@ -134,8 +134,8 @@ class SchemaParamConversionTest(unittest.TestCase):
     def test_cornice_location_synonyms(self):
 
         class RequestSchema(colander.MappingSchema):
-           header = HeaderSchema()
-           GET = QuerySchema()
+            header = HeaderSchema()
+            GET = QuerySchema()
 
         node = RequestSchema()
         params = self.handler.from_schema(node)

--- a/tests/test_parameter_handler.py
+++ b/tests/test_parameter_handler.py
@@ -131,6 +131,19 @@ class SchemaParamConversionTest(unittest.TestCase):
 
         self.assertNotEqual(params[0]['schema'], another_params[0]['schema'])
 
+    def test_cornice_location_synonyms(self):
+
+        class RequestSchema(colander.MappingSchema):
+           header = HeaderSchema()
+           GET = QuerySchema()
+
+        node = RequestSchema()
+        params = self.handler.from_schema(node)
+
+        names = [param['name'] for param in params]
+        expected = ['foo', 'bar']
+        self.assertEqual(sorted(names), sorted(expected))
+
 
 class PathParamConversionTest(unittest.TestCase):
 

--- a/tests/test_response_handler.py
+++ b/tests/test_response_handler.py
@@ -32,9 +32,9 @@ class SchemaResponseConversionTest(unittest.TestCase):
     def test_cornice_location_synonyms(self):
 
         class ReponseSchema(colander.MappingSchema):
-           header = HeaderSchema()
+            header = HeaderSchema()
 
-        responses_schemas = {'200': ReponseSchema('Return gelatto')}
+        response_schemas = {'200': ReponseSchema(description='Return gelatto')}
         responses = self.handler.from_schema_mapping(response_schemas)
 
         self.assertDictEqual(responses['200']['headers'],

--- a/tests/test_response_handler.py
+++ b/tests/test_response_handler.py
@@ -1,8 +1,9 @@
 import unittest
+import colander
 
 from cornice_swagger.swagger import ResponseHandler, CorniceSwaggerException
 from cornice_swagger.converters import convert_schema
-from .support import (BodySchema, ResponseSchema, response_schemas,
+from .support import (BodySchema, HeaderSchema, ResponseSchema, response_schemas,
                       DeclarativeSchema, AnotherDeclarativeSchema)
 
 
@@ -25,6 +26,17 @@ class SchemaResponseConversionTest(unittest.TestCase):
         responses = self.handler.from_schema_mapping(response_schemas)
         self.assertDictEqual(responses['200']['schema'],
                              convert_schema(BodySchema(title='BodySchema')))
+        self.assertDictEqual(responses['200']['headers'],
+                             {'bar': {'type': 'string'}})
+
+    def test_cornice_location_synonyms(self):
+
+        class ReponseSchema(colander.MappingSchema):
+           header = HeaderSchema()
+
+        responses_schemas = {'200': ReponseSchema('Return gelatto')}
+        responses = self.handler.from_schema_mapping(response_schemas)
+
         self.assertDictEqual(responses['200']['headers'],
                              {'bar': {'type': 'string'}})
 


### PR DESCRIPTION
Cornice supports exchanging `querystring` for `GET` and `headers` for `header` on the request schema.

https://github.com/Cornices/cornice/blob/master/cornice/validators/__init__.py#L61