### PR TITLE
Add support for parameter validators

### DIFF
--- a/cornice_swagger/converters/parameters.py
+++ b/cornice_swagger/converters/parameters.py
@@ -23,7 +23,9 @@ class ParameterConverter(object):
             converted['default'] = schema_node.default
 
         schema = definition_handler(schema_node)
-        converted['type'] = schema['type']
+        # Parameters shouldn't have a title
+        schema.pop('title')
+        converted.update(schema)
 
         if schema.get('type') == 'array':
             converted['items'] = {'type': schema['items']['type']}

--- a/tests/support.py
+++ b/tests/support.py
@@ -12,7 +12,8 @@ class BodySchema(colander.MappingSchema):
 
 
 class QuerySchema(colander.MappingSchema):
-    foo = colander.SchemaNode(colander.String(), missing=colander.drop)
+    foo = colander.SchemaNode(colander.String(), validator=colander.Length(3),
+                              missing=colander.drop)
 
 
 class HeaderSchema(colander.MappingSchema):

--- a/tests/test_parameter_handler.py
+++ b/tests/test_parameter_handler.py
@@ -52,7 +52,8 @@ class SchemaParamConversionTest(unittest.TestCase):
             'name': 'foo',
             'in': 'query',
             'type': 'string',
-            'required': False
+            'required': False,
+            'minLength': 3
         }
         self.assertDictEqual(params[0], expected)
 
@@ -209,7 +210,8 @@ class RefParamTest(unittest.TestCase):
             'name': 'foo',
             'in': 'query',
             'type': 'string',
-            'required': False
+            'required': False,
+            'minLength': 3
         }
 
         self.assertEquals(params, [{'$ref': '#/parameters/foo'}])


### PR DESCRIPTION
The only field from schema that's not allowed on parameters is `title`, so we may just drop it and use the schema validators.