### PR TITLE
Simplify the CorniceSwagger API

### DIFF
--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -372,14 +372,10 @@ class CorniceSwagger(object):
 
         :rtype: dict Full OpenAPI/Swagger compliant specification for the application.
         """
-        if title is None:
-            title = self.api_title
-        if version is None:
-            version = self.api_version
-        if info is None:
-            info = self.swagger.get('info', {})
-        if swagger is None:
-            swagger = self.swagger
+        title = title or self.api_title
+        version = version or self.api_version
+        info = info or self.swagger.get('info', {})
+        swagger = swagger or self.swagger
 
         swagger = swagger.copy()
         info.update(title=title, version=version)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,6 +10,7 @@ flex==6.0.1
 iso8601==0.1.11
 jsonpointer==1.10
 mccabe==0.5.3
+mock==2.0.0
 PasteDeploy==1.5.2
 pluggy==0.4.0
 py==1.4.32

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -10,8 +10,8 @@ Basic Generator
 .. py:module:: cornice_swagger
 
 .. autoclass:: cornice_swagger.swagger.CorniceSwagger
-.. automethod:: cornice_swagger.swagger.CorniceSwagger.__init__
-.. automethod:: cornice_swagger.swagger.CorniceSwagger.__call__
+    :members:
+    :member-order: bysource
 
 Generator Internals
 ===================

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -359,14 +359,14 @@ of tags or a callable that takes a cornice service and returns a list of tags.
         return [service.path.split('/')[1]]
 
     swagger = CorniceSwagger(get_services())
-    spec = swagger('IceCreamAPI', '4.2',
-                   default_tags=default_tag_callable)
+    swagger.default_tags = default_tag_callable
+    spec = swagger.generate('IceCreamAPI', '4.2')
 
 .. code-block:: python
 
     swagger = CorniceSwagger(get_services())
-    spec = swagger('IceCreamAPI', '4.2',
-                   default_tags=['MyAPI'])
+    swagger.default_tags = ['IceCream']
+    spec = swagger.generate('IceCreamAPI', '4.2')
 
 
 Generating summaries with view docstrings
@@ -387,7 +387,8 @@ the following swagger summary:
         """Returns the value."""
 
     swagger = CorniceSwagger(get_services())
-    spec = swagger('IceCreamAPI', '4.2', summary_docstrings=True)
+    swagger.summary_docstrings = True
+    spec = swagger.generate('IceCreamAPI', '4.2')
 
 
 .. code-block:: json

--- a/examples/minimalist.py
+++ b/examples/minimalist.py
@@ -61,8 +61,8 @@ swagger = Service(name='OpenAPI',
 
 @swagger.get()
 def openAPI_spec(request):
-    my_generator = CorniceSwagger(get_services())
-    my_spec = my_generator('MyAPI', '1.0.0')
+    doc = CorniceSwagger(get_services())
+    my_spec = doc.generate('MyAPI', '1.0.0')
     return my_spec
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ REQUIREMENTS_DEV = [
     'coveralls',
     'flake8',
     'flex',
+    'mock',
     'pyramid',
     'pytest',
     'pytest-cache',

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -32,7 +32,7 @@ class AppTest(unittest.TestCase):
         @api_service.get()
         def api_get(request):
             swagger = CorniceSwagger([service, api_service])
-            return swagger('IceCreamAPI', '4.2')
+            return swagger.generate('IceCreamAPI', '4.2')
 
         self.config = testing.setUp()
         self.config.include('cornice')


### PR DESCRIPTION
Following the discussion on #48, I propose this alternative way to the `CorniceSwagger` API. 

The diff is pretty messed up but I hope you can get the changes from the commits. It basically change most `__call__` method parameters to attributes and uses `generate` instead of `__call__`.

Opinions? r @glasserc 