### PR TITLE
Allow custom converters from CorniceSwagger class

### DIFF
--- a/cornice_swagger/converters/parameters.py
+++ b/cornice_swagger/converters/parameters.py
@@ -24,7 +24,7 @@ class ParameterConverter(object):
 
         schema = definition_handler(schema_node)
         # Parameters shouldn't have a title
-        schema.pop('title')
+        schema.pop('title', None)
         converted.update(schema)
 
         if schema.get('type') == 'array':

--- a/cornice_swagger/converters/schema.py
+++ b/cornice_swagger/converters/schema.py
@@ -237,26 +237,33 @@ class ArrayTypeConverter(TypeConverter):
 
 class TypeConversionDispatcher(object):
 
-    converters = {
-        colander.Boolean: BooleanTypeConverter,
-        colander.Date: DateTypeConverter,
-        colander.DateTime: DateTimeTypeConverter,
-        colander.Float: NumberTypeConverter,
-        colander.Integer: IntegerTypeConverter,
-        colander.Mapping: ObjectTypeConverter,
-        colander.Sequence: ArrayTypeConverter,
-        colander.String: StringTypeConverter,
-        colander.Time: TimeTypeConverter,
-    }
+    def __init__(self, custom_converters={}, default_converter=None):
+
+        self.converters = {
+            colander.Boolean: BooleanTypeConverter,
+            colander.Date: DateTypeConverter,
+            colander.DateTime: DateTimeTypeConverter,
+            colander.Float: NumberTypeConverter,
+            colander.Integer: IntegerTypeConverter,
+            colander.Mapping: ObjectTypeConverter,
+            colander.Sequence: ArrayTypeConverter,
+            colander.String: StringTypeConverter,
+            colander.Time: TimeTypeConverter,
+        }
+
+        self.converters.update(custom_converters)
+        self.default_converter = default_converter
 
     def __call__(self, schema_node):
-
         schema_type = schema_node.typ
         schema_type = type(schema_type)
 
         converter_class = self.converters.get(schema_type)
         if converter_class is None:
-            raise NoSuchConverter
+            if self.default_converter:
+                converter_class = self.default_converter
+            else:
+                raise NoSuchConverter
 
         converter = converter_class(self)
         converted = converter(schema_node)

--- a/tests/converters/test_schema.py
+++ b/tests/converters/test_schema.py
@@ -1,8 +1,12 @@
 import unittest
 import colander
 
+
 from cornice_swagger.converters import convert_schema as convert
+from cornice_swagger.converters import TypeConversionDispatcher
 from cornice_swagger.converters.exceptions import NoSuchConverter
+
+from ..support import AnyType, AnyTypeConverter
 
 
 class ConversionTest(unittest.TestCase):
@@ -20,6 +24,19 @@ class ConversionTest(unittest.TestCase):
             'maxLength': 42,
             'minLength': 12,
         })
+
+    def test_support_custom_converters(self):
+        node = colander.SchemaNode(AnyType())
+        custom_converters = {AnyType: AnyTypeConverter}
+        converter = TypeConversionDispatcher(custom_converters)
+        ret = converter(node)
+        self.assertEquals(ret, {})
+
+    def test_support_default_converter(self):
+        node = colander.SchemaNode(AnyType())
+        converter = TypeConversionDispatcher(default_converter=AnyTypeConverter)
+        ret = converter(node)
+        self.assertEquals(ret, {})
 
     def test_raise_no_such_converter_on_invalid_type(self):
         node = colander.SchemaNode(dict)

--- a/tests/support.py
+++ b/tests/support.py
@@ -1,5 +1,7 @@
 import colander
 
+from cornice_swagger.converters.schema import TypeConverter
+
 
 class MyNestedSchema(colander.MappingSchema):
     my_precious = colander.SchemaNode(colander.Boolean())
@@ -55,3 +57,14 @@ class AnotherDeclarativeSchema(colander.MappingSchema):
     @colander.instantiate(description='my another body')
     class body(colander.MappingSchema):
         timestamp = colander.SchemaNode(colander.Int())
+
+
+class AnyType(colander.SchemaType):
+    """A simple custom colander type."""
+    def deserialize(self, cstruct=colander.null):
+        return cstruct
+
+
+class AnyTypeConverter(TypeConverter):
+    def __call__(self, schema_node):
+        return {}

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -6,6 +6,7 @@ from cornice.service import Service
 from flex.core import validate
 
 from cornice_swagger.swagger import CorniceSwagger, CorniceSwaggerException
+
 from .support import (GetRequestSchema, PutRequestSchema, response_schemas,
                       BodySchema, HeaderSchema)
 


### PR DESCRIPTION
This introduces a way to set custom type converters straight from the `CorniceSwagger` class. It supports both a default type or a mapping of custom types. This allows setting additional type
converters without having to patch the `TypeConversionDispatcher` class.

Also deprecates the `converters.convert_xxx` functions.

Replaces: #48
Related to: #46