### PR TITLE
Handles Pyramid path regex and subpaths

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ CHANGES
 
 - Support subpaths and regex when parsing paths (#68).
 
+**Api**
+
+- ``_extract_path_from_service``, now returns the path name along with the path
+  swagger object (#68).
+
 
 0.5.0 (2017-02-14)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ CHANGES
 0.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Pyramid compliance**
+
+- Support subpaths and regex when parsing paths (#68).
 
 
 0.5.0 (2017-02-14)

--- a/cornice_swagger/converters/parameters.py
+++ b/cornice_swagger/converters/parameters.py
@@ -36,6 +36,30 @@ class ParameterConverter(object):
 class PathParameterConverter(ParameterConverter):
     _in = 'path'
 
+    def convert(self, schema_node, definition_handler):
+        converted = super(PathParameterConverter, self).convert(schema_node,
+                                                                definition_handler)
+        name = converted['name']
+        pattern = None
+
+        # Extract regex pattern from name
+        template = name.split(':', 1)
+        name = template[0]
+        if len(template) == 2:
+            pattern = template[1]
+
+        # handle traverse and subpath
+        # docs.pylonsproject.org/projects/pyramid/en/latest/narr/hybrid.html
+        for subpath_marker in ('*subpath', '*traverse'):
+            if name.find(subpath_marker) > 0:
+                name = subpath_marker[1:]
+
+        converted['name'] = name
+        if pattern:
+            converted['pattern'] = pattern
+
+        return converted
+
 
 class QueryParameterConverter(ParameterConverter):
     _in = 'query'

--- a/cornice_swagger/converters/parameters.py
+++ b/cornice_swagger/converters/parameters.py
@@ -39,24 +39,11 @@ class PathParameterConverter(ParameterConverter):
     def convert(self, schema_node, definition_handler):
         converted = super(PathParameterConverter, self).convert(schema_node,
                                                                 definition_handler)
-        name = converted['name']
-        pattern = None
-
         # Extract regex pattern from name
-        template = name.split(':', 1)
-        name = template[0]
+        template = converted['name'].split(':', 1)
         if len(template) == 2:
-            pattern = template[1]
-
-        # handle traverse and subpath
-        # docs.pylonsproject.org/projects/pyramid/en/latest/narr/hybrid.html
-        for subpath_marker in ('*subpath', '*traverse'):
-            if name.find(subpath_marker) > 0:
-                name = subpath_marker[1:]
-
-        converted['name'] = name
-        if pattern:
-            converted['pattern'] = pattern
+            converted['name'] = template[0]
+            converted['pattern'] = template[1]
 
         return converted
 

--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -148,6 +148,12 @@ class ParameterHandler(object):
         param_names = [comp[1:-1] for comp in path_components
                        if comp.startswith('{') and comp.endswith('}')]
 
+        # handle traverse and subpath
+        # docs.pylonsproject.org/projects/pyramid/en/latest/narr/hybrid.html
+        for subpath_marker in ('*subpath', '*traverse'):
+            if subpath_marker in path:
+                param_names.append(subpath_marker[1:])
+
         params = []
         for name in param_names:
             param_schema = colander.SchemaNode(colander.String(), name=name)

--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -1,5 +1,4 @@
 """Cornice Swagger 2.0 documentor"""
-import re
 import warnings
 
 import colander
@@ -145,8 +144,10 @@ class ParameterHandler(object):
         :type path: string
         :rtype: list
         """
+        path_components = path.split('/')
+        param_names = [comp[1:-1] for comp in path_components
+                       if comp.startswith('{') and comp.endswith('}')]
 
-        param_names = re.findall('\{(.*?)\}', path)
         params = []
         for name in param_names:
             param_schema = colander.SchemaNode(colander.String(), name=name)

--- a/tests/test_parameter_handler.py
+++ b/tests/test_parameter_handler.py
@@ -159,6 +159,16 @@ class PathParamConversionTest(unittest.TestCase):
         for param in params:
             self.assertEquals(param['in'], 'path')
 
+    def test_handles_path_regex(self):
+        params = self.handler.from_path('/my/{param:\\d+}/path/{id:[a-z]{8,42}}')
+        names = [param['name'] for param in params]
+        expected = ['param', 'id']
+        self.assertEqual(sorted(names), sorted(expected))
+
+    def test_handles_subpaths(self):
+        params = self.handler.from_path('/{**subpath}/path')
+        self.assertEqual(params[0]['name'], 'subpath')
+
 
 class RefParamTest(unittest.TestCase):
 

--- a/tests/test_parameter_handler.py
+++ b/tests/test_parameter_handler.py
@@ -167,10 +167,6 @@ class PathParamConversionTest(unittest.TestCase):
         self.assertEqual(named_params['param']['pattern'], '\\d+')
         self.assertEqual(named_params['id']['pattern'], '[a-z]{8,42}')
 
-    def test_handles_subpaths(self):
-        params = self.handler.from_path('/path/**subpath')
-        self.assertEqual(params[0]['name'], 'subpath')
-
 
 class RefParamTest(unittest.TestCase):
 

--- a/tests/test_parameter_handler.py
+++ b/tests/test_parameter_handler.py
@@ -161,12 +161,14 @@ class PathParamConversionTest(unittest.TestCase):
 
     def test_handles_path_regex(self):
         params = self.handler.from_path('/my/{param:\\d+}/path/{id:[a-z]{8,42}}')
-        names = [param['name'] for param in params]
+        named_params = {param['name']: param for param in params}
         expected = ['param', 'id']
-        self.assertEqual(sorted(names), sorted(expected))
+        self.assertEqual(sorted(named_params), sorted(expected))
+        self.assertEqual(named_params['param']['pattern'], '\\d+')
+        self.assertEqual(named_params['id']['pattern'], '[a-z]{8,42}')
 
     def test_handles_subpaths(self):
-        params = self.handler.from_path('/{**subpath}/path')
+        params = self.handler.from_path('/path/**subpath')
         self.assertEqual(params[0]['name'], 'subpath')
 
 

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -241,6 +241,27 @@ class ExtractContentTypesTest(unittest.TestCase):
         self.assertRaises(CorniceSwaggerException, swagger.generate)
 
 
+class ExtractPathTest(unittest.TestCase):
+
+    def test_handles_subpaths_as_parameters(self):
+        service = Service("IceCream", "/icecream/*subpath")
+
+        class IceCream(object):
+            @service.get()
+            def view_get(self, request):
+                return self.request
+
+        swagger = CorniceSwagger([service])
+        spec = swagger.generate()
+        expected = {
+            'name': 'subpath',
+            'required': True,
+            'type': 'string',
+            'in': 'path'
+        }
+        self.assertDictEqual(spec['paths']['/icecream/{subpath}']['parameters'][0], expected)
+
+
 class ExtractTransformSchemaTest(unittest.TestCase):
     def setUp(self):
         self.service = Service("IceCream", "/icecream/{flavour}")


### PR DESCRIPTION
Fixes: #68 
Related to: https://github.com/Kinto/kinto/issues/1180

Support path regex and subpath matching in Pyramid routes. 

Considerations:
- Subpaths are considered regular path attributes.
- Regex is used as the attribute pattern on the swagger documentation

Notes:
- Traverse and subpath are very primitive and only allow the definitions to be valid. Maybe we can try a better approach. Ideas?

r? @glasserc 