### PR TITLE
Handle callables for ``content_type`` argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ CHANGES
 0.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**Pyramid compliance**
+
+- Handle callables for ``cornice.service.Service.content_type`` argument.
+  For more details, see: http://cornice.readthedocs.io/en/latest/api.html#cornice.service.Service.
 
 
 0.5.2 (2017-11-07)

--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -585,15 +585,14 @@ class CorniceSwagger(object):
         # Get explicit accepted content-types
         consumes = args.get('content_type')
 
-        # convert to a list, if it's not yet one
-        consumes = to_list(consumes)
+        if consumes is not None:
+            # convert to a list, if it's not yet one
+            consumes = to_list(consumes)
 
-        # It is possible to add callables for ``content_type``.
-        # We have to filter those out because these are evaluated at
-        # request time.
-
-        consumes = [x for x in consumes if not callable(x)]
-        op['consumes'] = consumes
+            # It is possible to add callables for content_type, so we have to
+            # to filter those out, since we cannot evaluate those here.
+            consumes = [x for x in consumes if not callable(x)]
+            op['consumes'] = consumes
 
         # Get parameters from view schema
         schema = self._extract_transform_schema(args)

--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -2,6 +2,7 @@
 import warnings
 
 import colander
+from cornice.util import to_list
 import six
 
 from cornice_swagger.util import body_schema_transformer, merge_dicts, trim
@@ -584,12 +585,15 @@ class CorniceSwagger(object):
         # Get explicit accepted content-types
         consumes = args.get('content_type')
 
-        # A single content-type is provided, so wrap it in a list
-        if isinstance(consumes, six.string_types):
-            consumes = [consumes]
+        # convert to a list, if it's not yet one
+        consumes = to_list(consumes)
 
-        if consumes:
-            op['consumes'] = list(consumes)
+        # It is possible to add callables for ``content_type``.
+        # We have to filter those out because these are evaluated at
+        # request time.
+
+        consumes = [x for x in consumes if not callable(x)]
+        op['consumes'] = consumes
 
         # Get parameters from view schema
         schema = self._extract_transform_schema(args)

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -185,6 +185,49 @@ class ExtractContentTypesTest(unittest.TestCase):
         self.assertEquals(spec['paths']['/icecream/{flavour}']['put']['consumes'],
                           ['application/json', 'text/xml'])
 
+    def test_single_ctype_callable(self):
+
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        def my_ctype_callable(request):
+            return 'application/octet-stream'
+
+        class IceCream(object):
+            @service.put(content_type=my_ctype_callable)
+            def view_put(self, request):
+                return self.request.validated
+
+        swagger = CorniceSwagger([service])
+        spec = swagger.generate()
+        self.assertEquals(spec['paths']['/icecream/{flavour}']['put']['consumes'],
+                          [])
+
+    def test_mixed_ctype_string_and_callable(self):
+
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        def my_ctype_callable(request):
+            return 'application/octet-stream'
+
+        def my_ctype_callable_2(request):
+            return 'image/png'
+
+        class IceCream(object):
+            @service.put(content_type=(
+                    my_ctype_callable,
+                    'application/json',
+                    my_ctype_callable_2,
+                    'image/jpeg'
+                    )
+            )
+            def view_put(self, request):
+                return self.request.validated
+
+        swagger = CorniceSwagger([service])
+        spec = swagger.generate()
+        self.assertEquals(spec['paths']['/icecream/{flavour}']['put']['consumes'],
+                          ['application/json', 'image/jpeg'])
+
     def test_ignore_multiple_views_by_ctype(self):
 
         service = Service("IceCream", "/icecream/{flavour}")

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -171,6 +171,19 @@ class ExtractContentTypesTest(unittest.TestCase):
         self.assertEquals(spec['paths']['/icecream/{flavour}']['put']['consumes'],
                           ['application/json'])
 
+    def test_no_ctype_no_list_with_none(self):
+
+        service = Service("IceCream", "/icecream/{flavour}")
+
+        class IceCream(object):
+            @service.put()
+            def view_put(self, request):
+                return self.request.validated
+
+        swagger = CorniceSwagger([service])
+        spec = swagger.generate()
+        self.assertNotIn('consumes', spec['paths']['/icecream/{flavour}']['put'])
+
     def test_multiple_ctypes(self):
 
         service = Service("IceCream", "/icecream/{flavour}")


### PR DESCRIPTION
Handle callables for ``cornice.service.Service.content_type`` argument. For more details, see: http://cornice.readthedocs.io/en/latest/api.html#cornice.service.Service.