### PR TITLE
Fix Sphinx syntax

### DIFF
--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -66,7 +66,8 @@ class CorniceSwagger(object):
             You may add transformers to this pipeline when using custom schemas that
             doesn't correspond to the schemas used with `colander_validator`.
 
-        :rtype: dict Full OpenAPI/Swagger compliant specification for the application.
+        :returns: Full OpenAPI/Swagger compliant specification for the application.
+        :rtype: dict
         """
 
         info = info.copy()


### PR DESCRIPTION
Refs https://github.com/Kinto/kinto/pull/1514. Apparently Sphinx has
started to complain about unfindable things, and "dict followed by
some words" is unfindable.