### PR TITLE
BUGFIX: **kwargs should should land on spec view via `cornice_enable_openapi_view` directive

### DIFF
--- a/cornice_swagger/__init__.py
+++ b/cornice_swagger/__init__.py
@@ -39,7 +39,7 @@ def cornice_enable_openapi_view(
         config,
         api_path='/api-explorer/swagger.json',
         permission=NO_PERMISSION_REQUIRED,
-        route_factory=None):
+        route_factory=None, **kwargs):
     """
     :param config:
         Pyramid configurator object
@@ -49,10 +49,12 @@ def cornice_enable_openapi_view(
         pyramid permission for those views
     :param route_factory:
         factory for context object for those routes
+    :param kwargs:
+        kwargs that will be passed to CorniceSwagger's `generate()`
 
     This registers and configures the view that serves api definitions
     """
-
+    config.registry.settings['cornice_swagger.spec_kwargs'] = kwargs
     config.add_route('cornice_swagger.open_api_path', api_path,
                      factory=route_factory)
     config.add_view('cornice_swagger.views.open_api_json_view',
@@ -75,13 +77,9 @@ def cornice_enable_openapi_explorer(
         pyramid permission for those views
     :param route_factory:
         factory for context object for those routes
-    :param kwargs:
-        kwargs that will be passed to CorniceSwagger's `generate()`
 
     This registers and configures the view that serves api explorer
     """
-
-    config.registry.settings['cornice_swagger.spec_kwargs'] = kwargs
     config.add_route('cornice_swagger.api_explorer_path', api_explorer_path,
                      factory=route_factory)
     config.add_view('cornice_swagger.views.swagger_ui_template_view',

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -40,13 +40,13 @@ serve API explorer on your application::
     config.include('cornice')
     config.include('cornice_swagger')
     config.cornice_enable_openapi_view(
-        api_path='/api-explorer/swagger.json'
-    )
-    config.cornice_enable_openapi_explorer(
-        api_explorer_path='/api-explorer',
+        api_path='/api-explorer/swagger.json',
         title='MyAPI',
         description="OpenAPI documentation",
-        version='1.0.0')
+        version='1.0.0'
+    )
+    config.cornice_enable_openapi_explorer(
+        api_explorer_path='/api-explorer')
 
 Then you will be able to access Swagger UI API explorer on url:
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -22,11 +22,12 @@ your Pyramid config. For that you may use:
         config = Configurator()
         config.include('cornice')
         config.include('cornice_swagger')
-        config.cornice_enable_openapi_view()
-        config.cornice_enable_openapi_explorer(
+        config.cornice_enable_openapi_view(
             title='MyAPI',
             description="OpenAPI documentation",
-            version='1.0.0')
+            version='1.0.0'
+        )
+        config.cornice_enable_openapi_explorer()
 
 
 If you don't know what this is about or need more information, please check the

--- a/examples/minimalist.py
+++ b/examples/minimalist.py
@@ -58,14 +58,13 @@ def setup():
     config.include('cornice_swagger')
     # Create views to serve our OpenAPI spec
     config.cornice_enable_openapi_view(
-        api_path='/__api__'
-    )
-    # Create views to serve OpenAPI spec UI explorer
-    config.cornice_enable_openapi_explorer(
-        api_explorer_path='/api-explorer',
+        api_path='/__api__',
         title='MyAPI',
         description="OpenAPI documentation",
-        version='1.0.0')
+        version='1.0.0'
+    )
+    # Create views to serve OpenAPI spec UI explorer
+    config.cornice_enable_openapi_explorer(api_explorer_path='/api-explorer')
     config.scan()
     app = config.make_wsgi_app()
     return app


### PR DESCRIPTION
Hi, this is a bugfix PR, I'm sorry I've put the **kwargs passed to generate on wrong directive, thus making spec_view being dependent on explorer directive. I'm sorry about this oversight.
This PR fixes it along with tests that check the scenario where spec view is present without explorer view.