### PR TITLE
Support pyramid routes

### DIFF
--- a/cornice_swagger/__init__.py
+++ b/cornice_swagger/__init__.py
@@ -39,7 +39,7 @@ def cornice_enable_openapi_view(
         config,
         api_path='/api-explorer/swagger.json',
         permission=NO_PERMISSION_REQUIRED,
-        route_factory=None):
+        route_factory=None, **kwargs):
     """
     :param config:
         Pyramid configurator object
@@ -49,10 +49,12 @@ def cornice_enable_openapi_view(
         pyramid permission for those views
     :param route_factory:
         factory for context object for those routes
+    :param kwargs:
+        kwargs that will be passed to CorniceSwagger's `generate()`
 
     This registers and configures the view that serves api definitions
     """
-
+    config.registry.settings['cornice_swagger.spec_kwargs'] = kwargs
     config.add_route('cornice_swagger.open_api_path', api_path,
                      factory=route_factory)
     config.add_view('cornice_swagger.views.open_api_json_view',
@@ -75,13 +77,9 @@ def cornice_enable_openapi_explorer(
         pyramid permission for those views
     :param route_factory:
         factory for context object for those routes
-    :param kwargs:
-        kwargs that will be passed to CorniceSwagger's `generate()`
 
     This registers and configures the view that serves api explorer
     """
-
-    config.registry.settings['cornice_swagger.spec_kwargs'] = kwargs
     config.add_route('cornice_swagger.api_explorer_path', api_explorer_path,
                      factory=route_factory)
     config.add_view('cornice_swagger.views.swagger_ui_template_view',

--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -5,6 +5,7 @@ import warnings
 
 import colander
 from cornice.util import to_list
+from pyramid.threadlocal import get_current_registry
 import six
 
 from cornice_swagger.util import body_schema_transformer, merge_dicts, trim
@@ -353,7 +354,8 @@ class CorniceSwagger(object):
     """Base OpenAPI document that should be merged with the extracted info
     from the generate call."""
 
-    def __init__(self, services=None, def_ref_depth=0, param_ref=False, resp_ref=False):
+    def __init__(self, services=None, def_ref_depth=0, param_ref=False,
+                 resp_ref=False, pyramid_registry=None):
         """
         :param services:
             List of cornice services to document. You may use
@@ -370,13 +372,16 @@ class CorniceSwagger(object):
             Defines if swagger responses should be put inline on the operation
             or on the responses section and referenced by JSON pointers.
             Default is inline.
+        :param pyramid_registry:
+            Pyramid registry, should be passed if you use pyramid routes
+            instead of service level paths.
         """
         super(CorniceSwagger, self).__init__()
 
         type_converter = self.type_converter(self.custom_type_converters,
                                              self.default_type_converter)
         parameter_converter = self.parameter_converter(type_converter)
-
+        self.pyramid_registry = pyramid_registry
         if services is not None:
             self.services = services
 
@@ -540,6 +545,19 @@ class CorniceSwagger(object):
 
         path_obj = {}
         path = service.path
+        route_name = getattr(service, 'pyramid_route', None)
+        # handle services that don't create fresh routes,
+        # we still need the paths so we need to grab pyramid introspector to
+        # extract that information
+        if route_name:
+            registry = self.pyramid_registry or get_current_registry()
+            route_intr = registry.introspector.get('routes', route_name)
+            if route_intr:
+                path = route_intr['pattern']
+            else:
+                msg = 'Route `{}` is not found by ' \
+                      'pyramid introspector'.format(route_name)
+                raise ValueError(msg)
 
         # handle traverse and subpath as regular parameters
         # docs.pylonsproject.org/projects/pyramid/en/latest/narr/hybrid.html

--- a/cornice_swagger/views.py
+++ b/cornice_swagger/views.py
@@ -51,7 +51,8 @@ def open_api_json_view(request):
 
     Generates JSON representation of Swagger spec
     """
-    doc = cornice_swagger.CorniceSwagger(cornice.service.get_services())
+    doc = cornice_swagger.CorniceSwagger(
+        cornice.service.get_services(), pyramid_registry=request.registry)
     kwargs = request.registry.settings['cornice_swagger.spec_kwargs']
     my_spec = doc.generate(**kwargs)
     return my_spec

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -40,13 +40,13 @@ serve API explorer on your application::
     config.include('cornice')
     config.include('cornice_swagger')
     config.cornice_enable_openapi_view(
-        api_path='/api-explorer/swagger.json'
-    )
-    config.cornice_enable_openapi_explorer(
-        api_explorer_path='/api-explorer',
+        api_path='/api-explorer/swagger.json',
         title='MyAPI',
         description="OpenAPI documentation",
-        version='1.0.0')
+        version='1.0.0'
+    )
+    config.cornice_enable_openapi_explorer(
+        api_explorer_path='/api-explorer')
 
 Then you will be able to access Swagger UI API explorer on url:
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -22,11 +22,12 @@ your Pyramid config. For that you may use:
         config = Configurator()
         config.include('cornice')
         config.include('cornice_swagger')
-        config.cornice_enable_openapi_view()
-        config.cornice_enable_openapi_explorer(
+        config.cornice_enable_openapi_view(
             title='MyAPI',
             description="OpenAPI documentation",
-            version='1.0.0')
+            version='1.0.0'
+        )
+        config.cornice_enable_openapi_explorer()
 
 
 If you don't know what this is about or need more information, please check the

--- a/examples/minimalist.py
+++ b/examples/minimalist.py
@@ -58,14 +58,13 @@ def setup():
     config.include('cornice_swagger')
     # Create views to serve our OpenAPI spec
     config.cornice_enable_openapi_view(
-        api_path='/__api__'
-    )
-    # Create views to serve OpenAPI spec UI explorer
-    config.cornice_enable_openapi_explorer(
-        api_explorer_path='/api-explorer',
+        api_path='/__api__',
         title='MyAPI',
         description="OpenAPI documentation",
-        version='1.0.0')
+        version='1.0.0'
+    )
+    # Create views to serve OpenAPI spec UI explorer
+    config.cornice_enable_openapi_explorer(api_explorer_path='/api-explorer')
     config.scan()
     app = config.make_wsgi_app()
     return app


### PR DESCRIPTION
Now that `cornice` master supports reusing pyramid routes this should enable `cornice_swagger` to inspect the paths from service routes to generate required openapi information.

For tests to pass Cornice needs to get another release since stable does not have the required changes for this to work correctly.