### PR TITLE
Support pyramid routes

### DIFF
--- a/cornice_swagger/views.py
+++ b/cornice_swagger/views.py
@@ -51,7 +51,8 @@ def open_api_json_view(request):
 
     Generates JSON representation of Swagger spec
     """
-    doc = cornice_swagger.CorniceSwagger(cornice.service.get_services())
+    doc = cornice_swagger.CorniceSwagger(
+        cornice.service.get_services(), pyramid_registry=request.registry)
     kwargs = request.registry.settings['cornice_swagger.spec_kwargs']
     my_spec = doc.generate(**kwargs)
     return my_spec

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colander==1.4
-cornice==3.1.0
+cornice==3.2.0
 hupper==1.0
 iso8601==0.1.12
 PasteDeploy==1.5.2


### PR DESCRIPTION
Now that cornice master supports reusing pyramid routes this should enable cornice_swagger to inspect the paths from service routes to generate required openapi information.

For tests to pass Cornice needs to get another release since stable does not have the required changes for this to work correctly.