### PR TITLE
PoC: Support swagger ``example`` field for colander

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,12 @@ CHANGES
 0.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support swagger ``example`` field on colander ``SchemaNode`` custom kwarg::
+
+    def SomeSchema(colander.MappingSchema):
+        name = colander.SchemaNode(colander.String(), example='Mr. IceCream')
+
+  The ``example`` field is returned in the swagger spec accordingly.
 
 
 0.6.0 (2018-03-28)

--- a/cornice_swagger/converters/schema.py
+++ b/cornice_swagger/converters/schema.py
@@ -126,6 +126,8 @@ class TypeConverter(object):
             converted['description'] = schema_node.description
         if schema_node.default is not colander.null:
             converted['default'] = schema_node.default
+        if 'example' in schema_node.__dict__:
+            converted['example'] = schema_node.example
 
         return converted
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -11,6 +11,7 @@ class BodySchema(colander.MappingSchema):
     id = colander.SchemaNode(colander.String())
     timestamp = colander.SchemaNode(colander.Int())
     obj = MyNestedSchema()
+    ex = colander.SchemaNode(colander.String(), missing=colander.drop, example='example string')
 
 
 class QuerySchema(colander.MappingSchema):

--- a/tests/test_response_handler.py
+++ b/tests/test_response_handler.py
@@ -31,10 +31,10 @@ class SchemaResponseConversionTest(unittest.TestCase):
 
     def test_cornice_location_synonyms(self):
 
-        class ReponseSchema(colander.MappingSchema):
+        class ResponseSchema(colander.MappingSchema):
             header = HeaderSchema()
 
-        response_schemas = {'200': ReponseSchema(description='Return gelatto')}
+        response_schemas = {'200': ResponseSchema(description='Return gelatto')}
         responses = self.handler.from_schema_mapping(response_schemas)
 
         self.assertDictEqual(responses['200']['headers'],

--- a/tests/test_response_handler.py
+++ b/tests/test_response_handler.py
@@ -29,6 +29,17 @@ class SchemaResponseConversionTest(unittest.TestCase):
         self.assertDictEqual(responses['200']['headers'],
                              {'bar': {'type': 'string'}})
 
+    def test_response_schema_with_example(self):
+        class ResponseSchema(colander.MappingSchema):
+            body = BodySchema()
+
+        response_schemas = {'200': ResponseSchema(description='Return gelatto')}
+        responses = self.handler.from_schema_mapping(response_schemas)
+        self.assertTrue('ex' in responses['200']['schema']['properties'])
+        self.assertTrue('example' in responses['200']['schema']['properties']['ex'])
+        self.assertEquals(responses['200']['schema']['properties']['ex']['example'],
+                          'example string')
+
     def test_cornice_location_synonyms(self):
 
         class ResponseSchema(colander.MappingSchema):


### PR DESCRIPTION
This tackles one part of #85.