### PR TITLE
force string literal instead of unicode

### DIFF
--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -636,7 +636,7 @@ class CorniceSwagger(object):
                 view_ = getattr(ob, view.lower())
                 docstring = trim(view_.__doc__)
         else:
-            docstring = trim(view.__doc__)
+            docstring = str(trim(view.__doc__))
 
         if docstring and self.summary_docstrings:
             op['summary'] = docstring


### PR DESCRIPTION
Under Python 2, without the fix, the docstring shows an `u''` in swagger-ui because the unicode string is directly written in the json :

![image](https://user-images.githubusercontent.com/19194484/42247807-5f71cf42-7ef0-11e8-885e-24a6f4797e1c.png)

After the fix, the `u''` is properly parsed :  

![image](https://user-images.githubusercontent.com/19194484/42247844-a1cd5c3a-7ef0-11e8-9516-62da21f037c1.png)
