### PR TITLE
oneOf, allOf, anyOf, not - keyword for objects and arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,9 @@ target/
 # IPython Notebook
 .ipynb_checkpoints
 
+# PyCharm stuff
+.idea/
+
 # pyenv
 .python-version
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ CHANGES
 1.0.1 (unreleased)
 ------------------
 
-- Support oneOf, allOf, anyOf and not keywords for objects and arrays.
+- Support ``oneOf, allOf, anyOf, not`` keywords for objects and arrays.
   Requires ``openapi_spec=3`` when calling ``CorniceSwagger().generate()`` ::
 
     def OneOfSchema(colander.MappingSchema):

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,15 @@ CHANGES
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support oneOf, allOf, anyOf and not keywords for objects and arrays.
+  Requires ``openapi_spec=3`` when calling ``CorniceSwagger().generate()`` ::
+
+    def OneOfSchema(colander.MappingSchema):
+        name = colander.SchemaNode(colander.String())
+        id = colander.SchemaNode(colander.Integer())
+
+    def PetSchema(colander.MappingSchema):
+        pet = OneOfSchema(validator=colander.OneOf(['name', 'id']))
 
 
 1.0.0 (2020-03-31)

--- a/cornice_swagger/converters/parameters.py
+++ b/cornice_swagger/converters/parameters.py
@@ -17,7 +17,8 @@ class ParameterConverter(object):
             'required': schema_node.required
         }
         if schema_node.description:
-            converted['description'] = schema_node.description
+            # keep 'description' for back-compatibility
+            converted['summary'] = converted['description'] = schema_node.description
 
         if schema_node.default:
             converted['default'] = schema_node.default
@@ -67,7 +68,8 @@ class BodyParameterConverter(ParameterConverter):
             'required': schema_node.required
         }
         if schema_node.description:
-            converted['description'] = schema_node.description
+            # keep 'description' for back-compatibility
+            converted['summary'] = converted['description'] = schema_node.description
 
         schema_node.title = schema_node.__class__.__name__
         schema = definition_handler(schema_node)

--- a/cornice_swagger/converters/schema.py
+++ b/cornice_swagger/converters/schema.py
@@ -200,22 +200,28 @@ class ObjectTypeConverter(TypeConverter):
         converted = super(ObjectTypeConverter,
                           self).convert_type(schema_node)
 
-        properties = {}
-        required = []
+        if hasattr(converted, 'validator') and isinstance(
+                converted.validator, colander.OneOf):
+            converted = [self.dispatcher(sub_node)
+                         for sub_node in schema_node.children]
 
-        for sub_node in schema_node.children:
-            properties[sub_node.name] = self.dispatcher(sub_node)
-            if sub_node.required:
-                required.append(sub_node.name)
+        else:
+            properties = {}
+            required = []
 
-        if len(properties) > 0:
-            converted['properties'] = properties
+            for sub_node in schema_node.children:
+                properties[sub_node.name] = self.dispatcher(sub_node)
+                if sub_node.required:
+                    required.append(sub_node.name)
 
-        if len(required) > 0:
-            converted['required'] = required
+            if len(properties) > 0:
+                converted['properties'] = properties
 
-        if schema_node.typ.unknown == 'preserve':
-            converted['additionalProperties'] = {}
+            if len(required) > 0:
+                converted['required'] = required
+
+            if schema_node.typ.unknown == 'preserve':
+                converted['additionalProperties'] = {}
 
         return converted
 

--- a/cornice_swagger/converters/schema.py
+++ b/cornice_swagger/converters/schema.py
@@ -197,15 +197,20 @@ class ObjectTypeConverter(TypeConverter):
 
     def convert_type(self, schema_node):
 
-        converted = super(ObjectTypeConverter,
-                          self).convert_type(schema_node)
-
-        if hasattr(converted, 'validator') and isinstance(
-                converted.validator, colander.OneOf):
-            converted = [self.dispatcher(sub_node)
-                         for sub_node in schema_node.children]
+        if isinstance(schema_node.validator, (colander.OneOf, colander.Any)):
+            if isinstance(schema_node.validator, colander.OneOf):
+                of_type = 'oneOf'
+            else:
+                of_type = 'anyOf'
+            converted = {
+                of_type: [self.dispatcher(sub_node)
+                          for sub_node in schema_node.children]
+            }
 
         else:
+            converted = super(ObjectTypeConverter,
+                              self).convert_type(schema_node)
+
             properties = {}
             required = []
 

--- a/cornice_swagger/converters/schema.py
+++ b/cornice_swagger/converters/schema.py
@@ -122,7 +122,8 @@ class TypeConverter(object):
         if schema_node.title:
             converted['title'] = schema_node.title
         if schema_node.description:
-            converted['description'] = schema_node.description
+            # keep 'description' for back-compatibility
+            converted['summary'] = converted['description'] = schema_node.description
         if schema_node.default is not colander.null:
             converted['default'] = schema_node.default
         if 'example' in schema_node.__dict__:

--- a/cornice_swagger/converters/schema.py
+++ b/cornice_swagger/converters/schema.py
@@ -244,7 +244,7 @@ class ArrayTypeConverter(TypeConverter):
                           self).convert_type(schema_node)
 
         converted['items'] = self.dispatcher(schema_node.children[0])
-
+        converted['title'] = converted.get('title') or type(schema_node).__name__
         return converted
 
 

--- a/cornice_swagger/converters/schema.py
+++ b/cornice_swagger/converters/schema.py
@@ -197,11 +197,12 @@ class ObjectTypeConverter(TypeConverter):
 
     def convert_type(self, schema_node):
 
-        if isinstance(schema_node.validator, (colander.OneOf, colander.Any)):
-            if isinstance(schema_node.validator, colander.OneOf):
-                of_type = 'oneOf'
-            else:
-                of_type = 'anyOf'
+        of_types = {colander.OneOf: 'oneOf',
+                    colander.Any: 'anyOf',
+                    colander.All: 'allOf',
+                    colander.NoneOf: 'not'}
+        if isinstance(schema_node.validator, tuple(of_types.keys())):
+            of_type = of_types[type(schema_node.validator)]
             converted = {
                 of_type: [self.dispatcher(sub_node)
                           for sub_node in schema_node.children]

--- a/cornice_swagger/converters/schema.py
+++ b/cornice_swagger/converters/schema.py
@@ -204,18 +204,18 @@ class StringTypeConverter(BaseStringTypeConverter):
         if kwarg_format or kwarg_pattern:
             known_formats = {
                 # officials
-                'email': {'converter': StringTypeConverter, 'validator': colander.Email},
-                'url': {'converter': StringTypeConverter, 'validator': colander.url},
+                'email': {'converter': BaseStringTypeConverter, 'validator': colander.Email},
+                'url': {'converter': BaseStringTypeConverter, 'validator': colander.url},
                 'date': {'converter': DateTypeConverter, 'validator': None},
                 'date-time': {'converter': DateTimeTypeConverter, 'validator': None},
-                'password': {'converter': StringTypeConverter, 'validator': colander},
-                'binary': {'converter': StringTypeConverter, 'validator': colander.file_uri},
-                'byte': {'converter': StringTypeConverter, 'validator': colander.file_uri},
+                'password': {'converter': BaseStringTypeConverter, 'validator': colander},
+                'binary': {'converter': BaseStringTypeConverter, 'validator': colander.file_uri},
+                'byte': {'converter': BaseStringTypeConverter, 'validator': colander.file_uri},
                 # common but unofficial
                 'time': {'converter': TimeTypeConverter, 'validator': None},
-                'hostname': {'converter': StringTypeConverter, 'validator': colander.url},
-                'uuid': {'converter': StringTypeConverter, 'validator': colander.uuid},
-                'file': {'converter': StringTypeConverter, 'validator': colander.file_uri},
+                'hostname': {'converter': BaseStringTypeConverter, 'validator': colander.url},
+                'uuid': {'converter': BaseStringTypeConverter, 'validator': colander.uuid},
+                'file': {'converter': BaseStringTypeConverter, 'validator': colander.file_uri},
             }
             # extended conversion/validation for known ones
             if kwarg_format and kwarg_format.lower() in known_formats:
@@ -236,13 +236,13 @@ class StringTypeConverter(BaseStringTypeConverter):
                 if not isinstance(kwarg_pattern, colander.Regex):
                     raise NoSuchConverter(
                         "Provided string pattern object unknown: {!s}".format(kwarg_pattern))
-                format_converter_class = StringTypeConverter
+                format_converter_class = BaseStringTypeConverter
                 kwarg_format = None  # don't write 'pattern' as string format
                 if kwarg_validator is None:
                     setattr(schema_node, 'validator', kwarg_pattern)
             else:
                 # any value for 'format' is permitted and left as is for string definition
-                format_converter_class = StringTypeConverter
+                format_converter_class = BaseStringTypeConverter
 
             format_converter = format_converter_class(self.dispatcher)
             format_converter.format = kwarg_format

--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -473,6 +473,8 @@ class CorniceSwagger(object):
         if openapi_spec not in [2, 3]:
             raise CorniceSwaggerException('invalid OpenAPI specification version')
         self.openapi_spec = openapi_spec
+        setattr(self.type_converter, "openapi_spec", self.openapi_spec)
+        setattr(self.parameter_converter, "openapi_spec", self.openapi_spec)
 
         title = title or self.api_title
         version = version or self.api_version

--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -263,7 +263,7 @@ class ResponseHandler(object):
 
             response = {}
             if response_schema.description:
-                response['description'] = response_schema.description
+                response['summary'] = response_schema.description
             else:
                 raise CorniceSwaggerException('Responses must have a description.')
 

--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -2,7 +2,7 @@
 import inspect
 import warnings
 from collections import OrderedDict
-
+from distutils.version import LooseVersion
 
 import colander
 from cornice.util import to_list
@@ -460,6 +460,7 @@ class CorniceSwagger(object):
         :rtype: dict
         :returns: Full OpenAPI/Swagger compliant specification for the application.
         """
+        openapi_spec = LooseVersion(str(openapi_spec)).version[0]
         if openapi_spec not in [2, 3]:
             raise CorniceSwaggerException('invalid OpenAPI specification version')
         self.openapi_spec = openapi_spec

--- a/tests/converters/test_schema.py
+++ b/tests/converters/test_schema.py
@@ -296,6 +296,18 @@ class MappingConversionTest(unittest.TestCase):
             str = MappingStr()
             int = MappingInt()
 
+        class MappingTop2(colander.MappingSchema):
+            str = MappingStr(missing=colander.drop)
+            int = MappingInt(missing=colander.drop)
+            validator = colander.OneOf(['str', 'int'])
+
+
+        schema2 = MappingTop2(validator=colander.Function(
+            lambda value: isinstance(value, dict) and
+            any([k in value for k in ['int', 'str']])
+        ))
+        schema2.deserialize({'int': {'bar': 1}})
+
         schema = MappingTop(validator=colander.OneOf(['str', 'int']))
         ret = convert(schema)
         self.assertDictEqual(ret, {

--- a/tests/converters/test_schema.py
+++ b/tests/converters/test_schema.py
@@ -301,7 +301,6 @@ class MappingConversionTest(unittest.TestCase):
             int = MappingInt(missing=colander.drop)
             validator = colander.OneOf(['str', 'int'])
 
-
         schema2 = MappingTop2(validator=colander.Function(
             lambda value: isinstance(value, dict) and
             any([k in value for k in ['int', 'str']])

--- a/tests/converters/test_schema.py
+++ b/tests/converters/test_schema.py
@@ -272,10 +272,12 @@ class SequenceConversionTest(unittest.TestCase):
         class Integers(colander.SequenceSchema):
             num = colander.SchemaNode(colander.Integer())
 
-        ret = convert(Integers)
+        schema = Integers()
+        ret = convert(schema)
         self.assertDictEqual(ret, {
             'type': 'array',
             'items': {
+                'title': 'Num',
                 'type': 'integer',
             },
         })

--- a/tests/converters/test_schema.py
+++ b/tests/converters/test_schema.py
@@ -453,7 +453,8 @@ class SequenceConversionTest(unittest.TestCase):
         self.assertIn('items', ret)
         self.assertIn('oneOf', ret['items'])
         self.assertIsInstance(ret['items']['oneOf'], list)
-        self.assertItemsEqual(ret['items']['oneOf'], [
+
+        expected_oneof = [
             {
                 'type': 'object',
                 'title': 'Str',
@@ -476,4 +477,6 @@ class SequenceConversionTest(unittest.TestCase):
                 },
                 'required': ['bar']
             }
-        ])
+        ]
+        self.assertListEqual(sorted(ret['items']['oneOf'], key=lambda x: x['title']),
+                             sorted(expected_oneof, key=lambda x: x['title']))

--- a/tests/test_definition_handler.py
+++ b/tests/test_definition_handler.py
@@ -22,8 +22,8 @@ class AnxietySchema(colander.MappingSchema):
 
 
 class FeelingsSchema(colander.MappingSchema):
-    bleh = BoredoomSchema()
-    aaaa = AnxietySchema()
+    bleh = BoredoomSchema(missing=colander.drop)
+    aaaa = AnxietySchema(missing=colander.drop)
 
 
 class FeelingList(colander.SequenceSchema):

--- a/tests/test_definition_handler.py
+++ b/tests/test_definition_handler.py
@@ -63,3 +63,34 @@ class RefDefinitionTest(unittest.TestCase):
 
         self.assertDictContainsSubset(convert(AnxietySchema()),
                                       handler.definition_registry['Aaaa'])
+
+    def test_single_level_oneOf(self):
+        handler = DefinitionHandler(ref=1)
+        oneOf = colander.OneOf(['bleh', 'aaaa'])
+        feels = FeelingsSchema(title='Feelings', validator=oneOf)
+        ref = handler.from_schema(feels)
+
+        ref_feels = handler.definition_registry['Feelings']
+        self.assertEquals(ref, {'$ref': '#/definitions/Feelings'})
+        self.assertDictEqual(ref_feels, convert(feels))
+
+    def test_multi_level_oneOf(self):
+        handler = DefinitionHandler(ref=-1)
+        oneOf = colander.OneOf(['bleh', 'aaaa'])
+        feels = FeelingsSchema(title='Feelings', validator=oneOf)
+        ref1 = handler.from_schema(feels)
+        self.assertEquals(ref1, {'$ref': '#/definitions/Feelings'})
+
+        feelings_schema = {
+            'oneOf': [
+                {'$ref': '#/definitions/Aaaa'},
+                {'$ref': '#/definitions/Bleh'}
+            ]
+        }
+        feelings_refs = handler.definition_registry['Feelings']
+        self.assertIn('oneOf', feelings_refs)
+        self.assertIsInstance(feelings_refs['oneOf'], list)
+        self.assertItemsEqual(feelings_schema['oneOf'], feelings_refs['oneOf'])
+
+        self.assertDictContainsSubset(convert(AnxietySchema()),
+                                      handler.definition_registry['Aaaa'])

--- a/tests/test_definition_handler.py
+++ b/tests/test_definition_handler.py
@@ -102,8 +102,8 @@ class RefDefinitionTest(unittest.TestCase):
         feelings_refs = handler.definition_registry['Feelings']
         self.assertIn('oneOf', feelings_refs)
         self.assertIsInstance(feelings_refs['oneOf'], list)
-        self.assertItemsEqual(feelings_schema['oneOf'], feelings_refs['oneOf'])
-
+        self.assertListEqual(sorted(feelings_schema['oneOf'], key=lambda x: x['$ref']),
+                             sorted(feelings_refs['oneOf'], key=lambda x: x['$ref']))
         self.assertDictContainsSubset(convert(AnxietySchema()),
                                       handler.definition_registry['Aaaa'])
 
@@ -171,4 +171,5 @@ class RefDefinitionTest(unittest.TestCase):
         self.assertDictEqual(feel_list_schema, ref_feels)
         ref_feels_item = handler.definition_registry['FeelingListItem']
         self.assertIn('oneOf', ref_feels_item)
-        self.assertItemsEqual(ref_feels_item['oneOf'], feel_items)
+        self.assertListEqual(sorted(ref_feels_item['oneOf'], key=lambda x: x['$ref']),
+                             sorted(feel_items, key=lambda x: x['$ref']))


### PR DESCRIPTION
- adds support to `oneOf`, `allOf`, `anyOf` and `not` keywords for objects and arrays.
- adds `openapi_spec` input on `CorniceSwagger.generate()` to allow proper replacement of `swagger: 2.0` by `openapi: 3.0.0` in the generated json, which is required to display `oneOf`... 
- unittests to validate functionalities

```
def OneOfSchema(colander.MappingSchema):
    name = colander.SchemaNode(colander.String())
    id = colander.SchemaNode(colander.Integer())

def PetSchema(colander.MappingSchema):
    pet = OneOfSchema(validator=colander.OneOf(['name', 'id']))
```

baby step towards #69