### PR TITLE
Update 'produces' definition

### DIFF
--- a/cornice_swagger/swagger.py
+++ b/cornice_swagger/swagger.py
@@ -620,7 +620,7 @@ class CorniceSwagger(object):
         elif renderer == 'xml':
             produces = ['text/xml']
         else:
-            produces = None
+            produces = args.get('produces')
 
         if produces:
             op.setdefault('produces', produces)


### PR DESCRIPTION
Get produces from the args to be coherent with the comment and allow use of arbitrary type of value for 'produces'
# If 'produces' are not defined in the view, try get from renderers