### PR TITLE
Set default values to missing value

### DIFF
--- a/cornice_swagger/converters/schema.py
+++ b/cornice_swagger/converters/schema.py
@@ -124,7 +124,7 @@ class TypeConverter(object):
             converted['title'] = schema_node.title
         if schema_node.description:
             converted['description'] = schema_node.description
-        if schema_node.missing not in (colander.required, colander.drop):
+        if schema_node.missing not in (colander.required, colander.drop, colander.null):
             converted['default'] = schema_node.missing
         if 'example' in schema_node.__dict__:
             converted['example'] = schema_node.example

--- a/cornice_swagger/converters/schema.py
+++ b/cornice_swagger/converters/schema.py
@@ -124,7 +124,7 @@ class TypeConverter(object):
             converted['title'] = schema_node.title
         if schema_node.description:
             converted['description'] = schema_node.description
-        if schema_node.missing is not colander.null:
+        if schema_node.missing is not in (colander.required, colander.drop):
             converted['default'] = schema_node.missing
         if 'example' in schema_node.__dict__:
             converted['example'] = schema_node.example

--- a/cornice_swagger/converters/schema.py
+++ b/cornice_swagger/converters/schema.py
@@ -124,7 +124,7 @@ class TypeConverter(object):
             converted['title'] = schema_node.title
         if schema_node.description:
             converted['description'] = schema_node.description
-        if schema_node.missing is not in (colander.required, colander.drop):
+        if schema_node.missing not in (colander.required, colander.drop):
             converted['default'] = schema_node.missing
         if 'example' in schema_node.__dict__:
             converted['example'] = schema_node.example

--- a/cornice_swagger/converters/schema.py
+++ b/cornice_swagger/converters/schema.py
@@ -124,8 +124,8 @@ class TypeConverter(object):
             converted['title'] = schema_node.title
         if schema_node.description:
             converted['description'] = schema_node.description
-        if schema_node.default is not colander.null:
-            converted['default'] = schema_node.default
+        if schema_node.missing is not colander.null:
+            converted['default'] = schema_node.missing
         if 'example' in schema_node.__dict__:
             converted['example'] = schema_node.example
 

--- a/tests/converters/test_schema.py
+++ b/tests/converters/test_schema.py
@@ -53,7 +53,7 @@ class StringConversionTest(unittest.TestCase):
         })
 
     def test_validate_default(self):
-        node = colander.SchemaNode(colander.String(), default='foo')
+        node = colander.SchemaNode(colander.String(), missing='foo')
         ret = convert(node)
         self.assertDictEqual(ret, {
             'type': 'string',
@@ -134,7 +134,7 @@ class IntegerConversionTest(unittest.TestCase):
         })
 
     def test_default(self):
-        node = colander.SchemaNode(colander.Integer(), default=1)
+        node = colander.SchemaNode(colander.Integer(), missing=1)
         ret = convert(node)
         self.assertDictEqual(ret, {
             'type': 'integer',


### PR DESCRIPTION
In colander the attribute "missing" is used as default value for de-serialization; the "default" value is used only for serialization.
